### PR TITLE
Tooltips now include mob difficulty color...

### DIFF
--- a/Functions/SetTargetTooltipDisplay.lua
+++ b/Functions/SetTargetTooltipDisplay.lua
@@ -1,3 +1,5 @@
+local usingExperimentalTooltip = true
+
 function SetTargetTooltipDisplay(hideTargetTooltip)
   if not hideTargetTooltip then return end
 
@@ -11,16 +13,70 @@ function SetTargetTooltipDisplay(hideTargetTooltip)
       -- Hide health bar graphic under tooltip
       GameTooltipStatusBar:Hide()
 
-      -- Modify tooltip lines
-      for i = 2, self:NumLines() do
-        local line = _G['GameTooltipTextLeft' .. i]
-        if line then
-          local text = line:GetText()
-          if text and text:match('^Level') and not UnitIsPlayer(unit) then
-            line:SetText('') -- Remove level display for NPCs and enemies
+      if not usingExperimentalTooltip then
+
+        -- Modify tooltip lines
+        for i = 2, self:NumLines() do
+          local line = _G['GameTooltipTextLeft' .. i]
+          if line then
+            local text = line:GetText()
+            if text and text:match('^Level') and not UnitIsPlayer(unit) then
+              line:SetText('') -- Remove level display for NPCs and enemies
+            end
           end
         end
-      end
+
+      else -- usingExperimentalTooltip
+
+        -- Leave friendly NPC unit info alone.
+        if UnitIsFriend(unit, "player") and not UnitIsPlayer(unit) then
+          return
+        end
+
+        -- Append the guild name for players.
+        if UnitIsPlayer(unit) then
+          local guildName = GetGuildInfo(unit)
+          if guildName then
+            local line1 = _G['GameTooltipTextLeft1']
+            line1:SetText(line1:GetText() .. ' <' .. guildName .. '>')
+          end
+          return
+        end
+
+        -- If we get here, we know the unit is an enemy NPC.
+
+        -- Modify tooltip lines.
+        for i = 2, self:NumLines() do
+          local line = _G['GameTooltipTextLeft' .. i]
+          if line then
+
+            local text = line:GetText()
+            local pattern = "^Level%s+%d+%s*"
+            if text and text:match(pattern) then
+
+              -- Go back to line 1 and color the mob's name according to its difficulty.
+              local color = GetQuestDifficultyColor(UnitLevel(unit))
+              local hex6 = string.format("%02x%02x%02x", 255*color.r, 255*color.g, 255*color.b)
+              local line1 = _G['GameTooltipTextLeft1']
+              line1:SetText("|cFF" .. hex6 .. line1:GetText() .. "|r")
+
+              -- Remove "Level N" from the current line.
+              line:SetText(text:gsub(pattern, ""))
+
+            elseif text and text:match("^Level%s+%?%?%s*") then
+
+              -- Go back to line 1 and color the mob's name red.
+              local hex6 = "ff0000"
+              local line1 = _G['GameTooltipTextLeft1']
+              line1:SetText("|cFF" .. hex6 .. line1:GetText() .. "|r")
+
+            end
+          end
+        end
+
+      end -- usingExperimentalTooltip
+
     end)
   end)
+
 end


### PR DESCRIPTION
Also includes supplemental info like Elite/Skinnable/Corpse, and guild name for player characters.

I've tested this during several hours of game play, and it works as expected in every situation I've tried.

This is not yet ready to be published because (a) I don't know if it should be an additional option in Settings or just included for everyone; and (b) there is currently a local var that toggles the behavior. This is really just for beta testing, and should be remove or altered.

Philosophically I understand that there's an argument to be made for hiding as much information as possible, and I've seen the text in the UHC intro that mentions not knowing if a mob is a level 60 elite dragon or a level 1 bunny. But I believe players should have a *rough* idea of what kind of mob they're about to fight, especially if they're in an area they're not super familiar with. The color provides an important clue, as do the tunnel vision and the new damage overlays.