### PR TITLE
Update XPGainedTracker.lua

### DIFF
--- a/Functions/Statistics/TrackLowestHealth.lua
+++ b/Functions/Statistics/TrackLowestHealth.lua
@@ -1,20 +1,49 @@
--- 🟢 Track lowest health percentage
-function TrackLowestHealth()
-  local health = UnitHealth('player')
-  local maxHealth = UnitHealthMax('player')
-  local healthPercent = (health / maxHealth) * 100
+-- Track lowest health percentage
+local pvpPause = false
+local isDueling = false
 
-  local currentLowestHealth = CharacterStats:GetStat('lowestHealth')
-  if healthPercent < currentLowestHealth then
-    CharacterStats:UpdateStat('lowestHealth', healthPercent)
+local function TrackLowestHealth(event)
+  local health = UnitHealth("player")
+  local maxHealth = UnitHealthMax("player")
+
+  local healthPercent = (health / maxHealth) * 100
+  local currentLowestHealth = CharacterStats:GetStat("lowestHealth")
+
+  if pvpPause then
+    -- End pause after 1) not dueling, 2) HP% is above or equal to previous lowest, or you somehow died
+    if not isDueling and (healthPercent >= currentLowestHealth or health == 0) then
+      pvpPause = false
+      print("|cfff44336[Ultra Hardcore]|r |cfff0f000Health has returned above your previous lowest stat. Lowest Health tracking has resumed|r")
+    else
+      return
+    end
+  end
+
+  -- Only record new lows during normal tracking on UNIT_HEALTH and OUTSIDE of comabt
+  if event == "UNIT_HEALTH" and not UnitAffectingCombat("player") and healthPercent < currentLowestHealth then
+    CharacterStats:UpdateStat("lowestHealth", healthPercent)
   end
 end
 
--- Register the health tracking event
-local frame = CreateFrame('Frame')
-frame:RegisterEvent('UNIT_HEALTH')
-frame:SetScript('OnEvent', function(self, event, unit)
-  if unit == 'player' then
-    TrackLowestHealth()
+local frame = CreateFrame("Frame")
+frame:RegisterEvent("UNIT_HEALTH")
+frame:RegisterEvent("DUEL_REQUESTED") -- Fired when another player initiates a duel against you. Intentionally ignoring DUEL_TO_THE_DEATH_REQUESTED as that is full combat and should count
+frame:RegisterEvent("UNIT_SPELLCAST_SUCCEEDED") -- SpellID 7266 is Duel. Fired when player initiates the duel
+frame:RegisterEvent("DUEL_FINISHED") -- Fired every time a duel is over or cancelled
+frame:RegisterEvent("PLAYER_REGEN_DISABLED") -- In combat, if we want it
+frame:RegisterEvent("PLAYER_REGEN_ENABLED")  -- Out of combat, if we want it
+
+frame:SetScript("OnEvent", function(self, event, arg1, arg2, arg3)
+  if event == "UNIT_HEALTH" and arg1 ~= "player" then return end
+
+  if event == "DUEL_REQUESTED" or (event == "UNIT_SPELLCAST_SUCCEEDED" and arg1 == "player" and arg3 == 7266) then
+    pvpPause = true
+    isDueling = true
+    print("|cfff44336[Ultra Hardcore]|r |cfff0f000A duel has been initiated. Lowest Health tracking is paused|r")
+  elseif event == "DUEL_FINISHED" then
+    isDueling = false
+    print("|cfff44336[Ultra Hardcore]|r |cfff0f000Dueling has finished. Please wait for your health|r")
   end
-end) 
+
+  TrackLowestHealth(event)
+end)

--- a/Functions/XPGainedTracker.lua
+++ b/Functions/XPGainedTracker.lua
@@ -1,73 +1,103 @@
---[[
+--[[ 
   XP Tracking System - Tracks XP gained without the addon active
-  This system automatically tracks XP by comparing session start/end XP values
+  Compares "current total XP" to the last saved session end XP.
+  If first-time install (no lastSessionXP) and you are already > level 1 (or have nonzero XP),
+  we treat all current XP as "gained without the addon".
 ]]
+
+-- Static XP table (Classic Era/HC: XP to go from L -> L+1)
+local xpForLevel = {
+  [1]=400,[2]=900,[3]=1400,[4]=2100,[5]=2800,[6]=3600,[7]=4500,[8]=5400,[9]=6500,
+  [10]=7600,[11]=8800,[12]=10100,[13]=11400,[14]=12900,[15]=14400,[16]=16000,[17]=17700,[18]=19400,[19]=21300,
+  [20]=23200,[21]=25200,[22]=27300,[23]=29500,[24]=31700,[25]=34100,[26]=36600,[27]=39100,[28]=41800,[29]=44600,
+  [30]=47500,[31]=50500,[32]=53600,[33]=56800,[34]=60200,[35]=63700,[36]=67200,[37]=71000,[38]=74800,[39]=78700,
+  [40]=82800,[41]=87000,[42]=91300,[43]=95800,[44]=100400,[45]=105000,[46]=109800,[47]=114700,[48]=119700,[49]=124800,
+  [50]=130000,[51]=135200,[52]=140600,[53]=146000,[54]=151600,[55]=157300,[56]=163100,[57]=169000,[58]=175000,[59]=181000,
+}
 
 -- Session tracking variables
 local sessionStartXP = nil
-local lastSessionEndXP = nil
-local isAddonActive = true
+
+-- Calculate how much xp has been gained total
+local sessionStartXP = nil
+
+local function GetTotalXP()
+  -- Cumulative XP since level 1
+  local lvl = UnitLevel("player") or 1
+  local inLevelXP = UnitXP("player") or 0
+  local sum = 0
+  for L = 1, (lvl - 1) do
+    sum = sum + (xpForLevel[L] or 0)
+  end
+  return sum + inLevelXP
+end
+
+local function CS_GetStats()
+  if CharacterStats and CharacterStats.GetCurrentCharacterStats then
+    return CharacterStats:GetCurrentCharacterStats() or {}
+  end
+  return {}
+end
+
+local function CS_Update(key, value)
+  if CharacterStats and CharacterStats.UpdateStat then
+    CharacterStats:UpdateStat(key, value)
+  end
+end
 
 -- Function to initialize session tracking
 local function InitializeSessionTracking()
-  local characterGUID = UnitGUID('player')
-  local stats = CharacterStats:GetCurrentCharacterStats()
-  
-  -- Get the last session end XP from saved data
-  lastSessionEndXP = stats.lastSessionXP or 0
-  
-  -- Get current XP
-  local currentXP = UnitXP("player")
-  
-  -- If we have a last session end XP, calculate XP gained without addon
-  if lastSessionEndXP > 0 and currentXP > lastSessionEndXP then
-    local xpGainedWithoutAddon = currentXP - lastSessionEndXP
-    
-    -- Add this XP to the total XP gained without addon
-    local currentXPWithoutAddon = stats.xpGainedWithoutAddon or 0
-    local newXPWithoutAddon = currentXPWithoutAddon + xpGainedWithoutAddon
-    
-    CharacterStats:UpdateStat('xpGainedWithoutAddon', newXPWithoutAddon)
-    
+  local stats = CS_GetStats()
+  local lastSessionEndXP = tonumber(stats.lastSessionXP) or 0
+  local xpGainedWithoutAddon = tonumber(stats.xpGainedWithoutAddon) or 0
+
+  local currentXP = GetTotalXP()
+
+  -- Determine if player has used the addon before, if not ensure player is new (level 1)
+  if lastSessionEndXP > 0 then
+    local newXPWithoutAddon = currentXP - lastSessionEndXP
+    if newXPWithoutAddon > 0 then
+      CS_Update("xpGainedWithoutAddon", xpGainedWithoutAddon + newXPWithoutAddon)
+    end
+  else
+    local lvl = UnitLevel("player") or 1
+    local inLevelXP = UnitXP("player") or 0
+    if lvl > 1 or inLevelXP > 0 then
+      CS_Update("xpGainedWithoutAddon", currentXP)
+    end
   end
-  
-  -- Start new session with current XP
+
   sessionStartXP = currentXP
-  isAddonActive = true
-  
 end
 
 -- Function to end session and save data
 local function EndSession()
   if sessionStartXP then
-    local currentXP = UnitXP("player")
-    
-    -- Save the current XP as the last session end XP
-    CharacterStats:UpdateStat('lastSessionXP', currentXP)
-    
+    local currentXP = GetTotalXP()
+    CS_Update("lastSessionXP", currentXP)
   end
 end
 
 -- Function to get XP gained with addon (current session)
-local function GetXPWithAddon()
+ocal function GetXPWithAddon()
   if sessionStartXP then
-    local currentXP = UnitXP("player")
-    return currentXP - sessionStartXP
+    local currentXP = GetTotalXP()
+    return math.max(0, currentXP - sessionStartXP)
   end
   return 0
 end
 
 -- Function to display current XP tracking
 local function DisplayXP()
-  local xpWithout = CharacterStats:GetStat('xpGainedWithoutAddon') or 0
+  local stats = CS_GetStats()
+  local xpWithout = tonumber(stats.xpGainedWithoutAddon) or 0
   local xpWith = GetXPWithAddon()
-  local currentXP = UnitXP("player")
-  
+  local currentXP = GetTotalXP()
+  local totalXPGained = xpWithout + xpWith
+
   print("UHC - XP gained with addon (this session): " .. xpWith)
   print("UHC - Total XP gained without addon: " .. xpWithout)
-  print("UHC - Current character XP: " .. currentXP)
-  
-  local totalXPGained = xpWithout + xpWith
+  print("UHC - Current character XP (lifetime): " .. currentXP)
   print("UHC - Total XP gained across all sessions: " .. totalXPGained)
 end
 


### PR DESCRIPTION
Updated to accurately get characters total xp since just using UnitXP() is based on level only. This now covers between session xp without the addon or when a player starts Ultra Hardcore after level 1.