### PR TITLE
[Bug Fix] - Feign Death Enabled TrackLowestHealth.lua

### DIFF
--- a/Functions/Statistics/TrackLowestHealth.lua
+++ b/Functions/Statistics/TrackLowestHealth.lua
@@ -12,7 +12,7 @@ local function TrackLowestHealth(event)
   local currentLowestHealth = CharacterStats:GetStat("lowestHealth")
   local currentLowestHealthThisLevel = CharacterStats:GetStat("lowestHealthThisLevel")
   local currentLowestHealthThisSession = CharacterStats:GetStat("lowestHealthThisSession")
-
+  
   -- Return early if any stats are nil (not initialized yet)
   if not currentLowestHealth or not currentLowestHealthThisLevel or not currentLowestHealthThisSession then
     return
@@ -101,12 +101,12 @@ frame:SetScript("OnEvent", function(self, event, arg1, arg2, arg3)
       local currentLowestHealth = CharacterStats:GetStat("lowestHealth")
       if pendingCombatLow < currentLowestHealth then
         CharacterStats:UpdateStat("lowestHealth", pendingCombatLow)
-        if pendingCombatLow < CharacterStats:GetStat("lowestHealthThisLevel") then
+      end
+      if pendingCombatLow < CharacterStats:GetStat("lowestHealthThisLevel") then
           CharacterStats:UpdateStat("lowestHealthThisLevel", pendingCombatLow)
         end
-        if pendingCombatLow < CharacterStats:GetStat("lowestHealthThisSession") then
-          CharacterStats:UpdateStat("lowestHealthThisSession", pendingCombatLow)
-        end
+      if pendingCombatLow < CharacterStats:GetStat("lowestHealthThisSession") then
+        CharacterStats:UpdateStat("lowestHealthThisSession", pendingCombatLow)
       end
     end
     pendingCombatLow = nil


### PR DESCRIPTION
We have to cache the lowest health now since feign death is used in combat and we want to track health up until that point but continue to not show lowest health stats decreasing in combat...

eg. You are at 5% (a new low) and you use Feign Death. As soon as you leave combat the lowest health tracker displays the 5% new low and NOT the 0% from your Feign Death.