### PR TITLE
[UI Improvement?] Try to center buffs over the resource bar

### DIFF
--- a/Functions/Overlays/CustomResourceBar.lua
+++ b/Functions/Overlays/CustomResourceBar.lua
@@ -291,7 +291,7 @@ function CenterPlayerBuffBar()
     if BuffFrame then
         local continuationToken;
         local buffCount = 0;
-        local pixelsToMove = 12;
+        local pixelsToMove = 13.25;
         local xOffset = 0;
         local yOffset = 5;
         local buffRows = 1;


### PR DESCRIPTION
The WoW buff frame shows buffs in a right to left fashion which makes multiple buffs show up off center above the resource bar.  This PR is my feeble attempt to center the icons.  I also attempted to try to move the bar up if the player gets more than 10 buffs (I couldn't test this).

There are some print statements in the code that you can uncomment to see what these changes are trying to do.