### PR TITLE
[IGNORE] Updated Centered Player Buffs implementation

### DIFF
--- a/Functions/Overlays/CustomResourceBar.lua
+++ b/Functions/Overlays/CustomResourceBar.lua
@@ -371,7 +371,7 @@ local function RepositionPlayerBuffBar()
     -- Wait for buff frame to be created
     C_Timer.After(0.5, function()
         if comboFrame:IsVisible() then 
-            print("Combo frame visible, adjusting buff frame position")
+            -- print("Combo frame visible, adjusting buff frame position")
             CustomBuffFrame.YOffset = 0
             CustomBuffFrame:SetPoint('BOTTOM', comboFrame, 'TOP', 0, CustomBuffFrame.YOffset);
         else


### PR DESCRIPTION
These changes create two frames to hold buffs and debuffs separately.  It draws icons for each buff/debuff and dynamically resizes the respective frame to hold the icons for the current buffs (or debuffs).

Because these icons are not interactive (i.e. you can't click them off) and there are no timers, the default WoW buff frame is left as is near the top right.  

I updated the title of this to IGNORE because it lacks functionality that the users want.  Namely timers on the resource bar buffs and the ability to click them off.