### PR TITLE
[New Feature] Shows hearth overlay only when player or party member is in combat

### DIFF
--- a/Functions/Overlays/ShowHearthOverlay.lua
+++ b/Functions/Overlays/ShowHearthOverlay.lua
@@ -1,4 +1,5 @@
 local hearthingOverlayFrame = nil
+local frameIsShowing = false
 
 function ShowHearthingOverlay()
     if not hearthingOverlayFrame then
@@ -26,12 +27,18 @@ function ShowHearthingOverlay()
 
     hearthingOverlayFrame:Show()
     UIFrameFadeIn(hearthingOverlayFrame, 0.3, 0, 1)
+    frameIsShowing = true
 end
 
 function HideHearthingOverlay()
-    if hearthingOverlayFrame and hearthingOverlayFrame:IsShown() then
+    -- Only hide if the frame exists and is currently showing based on frameIsShowing
+    -- This prevents the overlay from flickering 
+    if hearthingOverlayFrame and hearthingOverlayFrame:IsVisible() and frameIsShowing then
         UIFrameFadeOut(hearthingOverlayFrame, 0.3, 1, 0, function()
+            hearthingOverlayFrame:SetAlpha(0)
             hearthingOverlayFrame:Hide()
         end)
+
+        frameIsShowing = false
     end
 end

--- a/UltraHardcore.lua
+++ b/UltraHardcore.lua
@@ -77,8 +77,25 @@ UltraHardcore:SetScript('OnEvent', function(self, event, ...)
   elseif event == 'UNIT_SPELLCAST_START' then
     -- Check for Hearthstone casting start
     local unit, castGUID, spellID = ...
+
     if unit == "player" and spellID == 8690 then -- 8690 is Hearthstone spell ID
-      HearthingOverlay()
+      local affectingCombat = UnitAffectingCombat("player");
+      local partyInCombat = false
+
+      --print("Player combat status: " .. tostring(affectingCombat))
+      -- party1 is always the player
+      for i = 1, 5 do
+        local partyUnit = "party"..i
+        --print("Party member " .. i .. " combat status: " .. tostring(UnitAffectingCombat(partyUnit)))
+        if UnitAffectingCombat(partyUnit) then
+          partyInCombat = true
+          break
+        end
+      end
+
+      if affectingCombat or partyInCombat then
+        HearthingOverlay()
+      end
     end
   elseif event == 'UNIT_SPELLCAST_STOP' or event == 'UNIT_SPELLCAST_SUCCEEDED' or event == 'UNIT_SPELLCAST_FAILED' or event == 'UNIT_SPELLCAST_INTERRUPTED' then
     -- Check for Hearthstone casting end


### PR DESCRIPTION
Also fixes the brief display of overlay after chain casting and canceling hearth out of combat