### PR TITLE
[New Feature] Track XP gained with Addon plus verification mechanism

### DIFF
--- a/Functions/Statistics/TrackXPPerSetting.lua
+++ b/Functions/Statistics/TrackXPPerSetting.lua
@@ -6,6 +6,8 @@
 -- Mapping of setting names to their XP tracking variables
 -- Organized by preset type: Lite, Recommended, Experimental
 local settingToXPVariable = {
+  -- Addon XP gained for reporting when addon is turned off (not a setting!)
+  xpGainedWithAddon = 'xpGWA',
   -- Lite Preset Settings
   hidePlayerFrame = 'xpGainedWithoutOptionHidePlayerFrame',
   showOnScreenStatistics = 'xpGainedWithoutOptionShowOnScreenStatistics',
@@ -39,8 +41,25 @@ local lastXPValue = nil
 -- Function to initialize XP tracking
 local function InitializeXPTracking()
   -- Start tracking from current XP for this session
+  local playerLevel = UnitLevel("player")
   lastXPValue = UnitXP("player")
   lastXPUpdate = GetTime()
+
+  -- Frequently player XP reports as 0 when entering the game, wait a sec and retry
+  if lastXPValue == 0 and playerLevel > 1 then
+    C_Timer.After(1.0, function() 
+      lastXPValue = UnitXP("player")
+      lastXPUpdate = GetTime()
+    end)
+  end
+  -- Do this to preload all stats
+  local stats = CharacterStats:GetCurrentCharacterStats()
+  -- print('Saved XP Gained with Addon is ' .. tostring(stats.xpGWA) .. '. Last XP value: ' .. lastXPValue)
+  if stats.xpGWA == nil and lastXPValue > 0 then
+    -- It looks like sometimes player XP is reported as 0 as you enter the world
+    -- Try a timer to wait it out
+    CharacterStats:ResetXPGainedWithAddon(true)
+  end
 end
 
 -- Function to update XP tracking for each setting
@@ -58,13 +77,14 @@ local function UpdateXPTracking()
       local isSettingEnabled = GLOBAL_SETTINGS[settingName]
       
       -- For boolean settings, if they're false, we're gaining XP "without" that option
-      if not isSettingEnabled then
+      -- xpGWA is the opposite of the normal behavior, we're tracking all XP with the addon enabled
+      if not isSettingEnabled or xpVariable == "xpGWA" then 
         local currentXPForSetting = CharacterStats:GetStat(xpVariable) or 0
         local newXPForSetting = currentXPForSetting + xpGained
         CharacterStats:UpdateStat(xpVariable, newXPForSetting)
       end
     end
-    
+
     -- NOTE: We do NOT update the general "without addon" tracking here
     -- That should be handled by the original XPGainedTracker.lua system
     

--- a/Functions/Utils/FormatNumber.lua
+++ b/Functions/Utils/FormatNumber.lua
@@ -24,3 +24,12 @@ function formatNumberWithCommas(number)
 
   return formatted
 end
+
+function getDigitsFromString(num)
+    local num_str = tostring(num)
+    local digits = {}
+    for i = 1, #num_str do
+        table.insert(digits, tonumber(num_str:sub(i, i)))
+    end
+    return digits
+end


### PR DESCRIPTION
These changes should retroactively calculate a value for a new hidden statistic labeled xpGWA.  xpGWA is "xp Gained With Addon".  The retroactive value is based on the current character XP minus the value of  the smallest "xpGainedWithout" statistic.   It is assumed the smallest "xpGainedWithout" statistic is the stat that was tracked the longest with the addon enabled.  Once xpGWA is calculated, it is tracked just like the other statistics, except there is no off switch.

If one disables the addon and gains XP, the value of xpGWA does not increase.  As developers we can use a new function called CharacterStats:ReportXPWithoutAddon() to get the value of XP gained without the addon.  If a value cannot be calculated, the function returns false.

The /uhcv message has been updated to show Total XP, XP w/o UHC and a new checksum value.   While the checksum logic is very simple, it should be tricky enough so non-developers won't know how to game it.

<img width="621" height="45" alt="image" src="https://github.com/user-attachments/assets/ed9718b2-409b-45f5-9fda-a01860787465" />

A new command has been added: **/uhcxp** that accepts another player's total xp, xp without addon and their level.  It will then print the calculated checksum that the person can use to determine if a /uhcv message is fake or not.

Example:
`/uhcxp 2564 0 5`

Output:
`[ULTRA] Player checksum should be 3.40`

<img width="370" height="62" alt="image" src="https://github.com/user-attachments/assets/e79bcc09-2b13-4ec1-957e-9df8ab03142c" />

If /uhcxp is run without arguments, a usage example is printed instead.
