### PR TITLE
[Bug Fix] Implement 56c17d9 changes in SetNameplateDisabled.lua

### DIFF
--- a/UltraHardcore.lua
+++ b/UltraHardcore.lua
@@ -157,31 +157,3 @@ UltraHardcore:SetScript('OnEvent', function(self, event, ...)
     DuelTracker(...)
   end
 end)
-
--- Utility: run a function once combat ends (or immediately if not in combat)
-local function RunWhenOutOfCombat(callback)
-  if not InCombatLockdown() then
-    callback()
-    return
-  end
-  local waitFrame = CreateFrame("Frame")
-  waitFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
-  waitFrame:SetScript("OnEvent", function(self)
-    self:UnregisterEvent("PLAYER_REGEN_ENABLED")
-    self:SetScript("OnEvent", nil)
-    callback()
-  end)
-end
-
-local f = CreateFrame("Frame")
-f:RegisterEvent("CVAR_UPDATE")
-f:SetScript("OnEvent", function(self, event, cvar, value)
-    if cvar == "nameplateShowEnemies" or cvar == "nameplateShowFriends" or cvar == "nameplateShowAll" then
-        -- force them off again
-        RunWhenOutOfCombat(function()
-          SetCVar("nameplateShowEnemies", 0)
-          SetCVar("nameplateShowFriends", 0)
-          SetCVar("nameplateShowAll", 0)
-        end)
-    end
-end)


### PR DESCRIPTION
This fixes the problem introduced by commit 56c17d9  where the disable nameplates setting is ignored.  It implements the same method of listening for CVAR_UPDATE events to control the nameplate cvars that can have a hotkey assigned to them.  It also implements the temporary event listener for PLAYER_REGEN_ENABLED to automatically disable nameplates out of combat if one of the hotkeys is pressed in combat.

The existing logic that handles all of the nameplate cvars that do not have a hotkey is left as is so those can be controlled as they previously were.