### PR TITLE
Fix action bar visibility when flying

### DIFF
--- a/Functions/SetActionBarVisibility.lua
+++ b/Functions/SetActionBarVisibility.lua
@@ -21,7 +21,6 @@ function SetActionBarVisibility(hideActionBars, playerLevel)
 
   if hideActionBars and playerLevel >= MIN_LEVEL_HIDE_ACTION_BARS then
     local inCombat = UnitAffectingCombat('player') == true
-    local onTaxi = UnitOnTaxi('player')
     if (IsResting() or 
         HasCozyFire() or 
         UnitOnTaxi('player') or 


### PR DESCRIPTION
Added events for lost and gained control that have a slight delay before calling the action bar visibility code.  Calling it right when the event triggers still has UnitOnTaxi returning false.