### PR TITLE
Resubmit Questie Compliant SetTargetTooltipDisplay

### DIFF
--- a/Functions/SetTargetTooltipDisplay.lua
+++ b/Functions/SetTargetTooltipDisplay.lua
@@ -1,34 +1,37 @@
 function SetTargetTooltipDisplay(hideTargetTooltip)
   if not hideTargetTooltip then return end
 
-  hooksecurefunc('GameTooltip_SetDefaultAnchor', function(tooltip)
-    tooltip:SetScript('OnTooltipSetUnit', function(self)
-      local unit = select(2, self:GetUnit())
+  hooksecurefunc('GameTooltip_SetDefaultAnchor', function(tooltip, parent)
+  end)
+
+  if not GameTooltip._MyAddon_UnitHooked then
+    GameTooltip._MyAddon_UnitHooked = true
+
+    local frame = GameTooltip
+    frame:HookScript('OnTooltipSetUnit', function(self)
+      local _, unit = self:GetUnit()
       if not unit then return end
 
-      -- Hide health bar graphic under tooltip
+      -- Hide health bar
       GameTooltipStatusBar:Hide()
 
-      -- Check if unit is tapped by another player and in combat, modify first line (name) color
-      if UnitIsTapDenied(unit) then
-        local nameLine = _G['GameTooltipTextLeft1']
-        if nameLine then
-          nameLine:SetTextColor(0.5, 0.5, 0.5) -- Gray color
-        end
-      end
-
-      -- Modify tooltip lines
-      for i = 2, self:NumLines() do
-        local line = _G['GameTooltipTextLeft' .. i]
-        if line then
-          local text = line:GetText()
-          if text and not UnitIsPlayer(unit) then
-            if text:match(LEVEL) then
-              line:SetText('')
+      -- Delay the level line removal to ensure tooltip is fully built (this makes it so it runs last and retains information each time you hover)
+      C_Timer.After(0.0, function()
+        for i = 2, self:NumLines() do
+          local line = _G['GameTooltipTextLeft' .. i]
+          if line then
+            local text = line:GetText()
+            if text then
+              if text:match(LEVEL) and not UnitIsPlayer(unit) then
+                line:SetText(nil)
+                break -- Stop after removing the level line
+              end
             end
           end
         end
-      end
+        -- Refresh tooltip to remove empty line
+        self:Show()
+      end)
     end)
-  end)
+  end
 end


### PR DESCRIPTION
Tooltip is no longer 'overriden' and instead just removes the level line and redisplays it allowing other addons to include themselves in the tooltip