### PR TITLE
Update on screen jumps as they happen

### DIFF
--- a/Functions/Overlays/MainScreenStatistics.lua
+++ b/Functions/Overlays/MainScreenStatistics.lua
@@ -457,7 +457,7 @@ local function CheckAddonEnabled()
 end
 
 -- Function to update all statistics
-local function UpdateStatistics()
+function UpdateStatistics()
   if not UltraHardcoreDB then
     LoadDBData()
   end

--- a/Functions/Statistics/TrackJumps.lua
+++ b/Functions/Statistics/TrackJumps.lua
@@ -16,6 +16,7 @@ jumpTrackingFrame:SetScript("OnEvent", function(self, event, ...)
     self.count = self.count + 1
     self.lastJump = GetTime()
     CharacterStats:UpdateStat('playerJumps', JumpCounter.count)
+    UpdateStatistics()
   end
 
   -- Hook AscendStop to detect player jumps


### PR DESCRIPTION
The updates are still limited to no more than once every .75s

We call UpdateStatistics() significantly more in combat with the UNIT_HEALTH_FREQUENT and COMBAT_LOG_EVENT_UNFILTERED events.  

Compared to combat updates, this should not have any performance impact. It looks better when you are tracking jumps on screen instead of thinking there is something wrong with the tracking while we wait for a different event to trigger an update.