### PR TITLE
Gate trying to call LoadDB before the addon has fully loaded

### DIFF
--- a/Functions/DB/CharacterStats.lua
+++ b/Functions/DB/CharacterStats.lua
@@ -208,6 +208,10 @@ end
 function CharacterStats:GetCurrentCharacterStats()
   local characterGUID = UnitGUID('player')
 
+  if statsInitialized then
+    return UltraHardcoreDB.characterStats[characterGUID]
+  end
+
   -- Initialize character stats if they don't exist
   if not UltraHardcoreDB.characterStats then
     UltraHardcoreDB.characterStats = {}
@@ -218,18 +222,17 @@ function CharacterStats:GetCurrentCharacterStats()
   end
 
   -- Initialize new stats for existing characters (backward compatibility)
-  local stats = UltraHardcoreDB.characterStats[characterGUID]
 
   if not statsInitialized then
     for statName, _ in pairs(self.defaults) do
-      if stats[statName] == nil then
-        stats[statName] = self.defaults[statName]
+      if UltraHardcoreDB.characterStats[characterGUID][statName] == nil then
+        UltraHardcoreDB.characterStats[characterGUID][statName] = self.defaults[statName]
       end
     end
     statsInitialized = true
   end
 
-  return stats
+  return UltraHardcoreDB.characterStats[characterGUID]
 end
 
 -- Update a specific stat for the current character

--- a/Functions/Overlays/MainScreenStatistics.lua
+++ b/Functions/Overlays/MainScreenStatistics.lua
@@ -1,6 +1,9 @@
 -- Main Screen Statistics Display
 -- Shows the same statistics that appear in the settings panel, but on the main screen at all times
 
+-- To gate activity until the addon is fully loaded
+local isAddonLoaded = false
+
 -- Create the main statistics frame (invisible container for positioning)
 local statsFrame = CreateFrame('Frame', 'UltraHardcoreStatsFrame', UIParent)
 statsFrame:SetSize(200, 360) -- Increased height to accommodate all statistics including tunnel vision overlay
@@ -458,6 +461,10 @@ end
 
 -- Function to update all statistics
 local function UpdateStatistics()
+  if not isAddonLoaded then
+    return
+  end
+
   if not UltraHardcoreDB then
     LoadDBData()
   end
@@ -572,20 +579,21 @@ statsFrame:RegisterEvent('COMBAT_LOG_EVENT_UNFILTERED')
 statsFrame:RegisterEvent('PLAYER_LEVEL_UP')
 statsFrame:RegisterEvent('ADDON_LOADED') -- Check setting when addon loads
 statsFrame:SetScript('OnEvent', function(self, event, ...)
-  if event == 'PLAYER_ENTERING_WORLD' then
+  if event == 'PLAYER_ENTERING_WORLD' and isAddonLoaded then
     UpdateStatistics()
     CheckAddonEnabled()
-  elseif event == 'UNIT_HEALTH_FREQUENT' then
+  elseif event == 'UNIT_HEALTH_FREQUENT' and isAddonLoaded then
     -- Update lowest health when health changes
     UpdateStatistics()
-  elseif event == 'COMBAT_LOG_EVENT_UNFILTERED' then
+  elseif event == 'COMBAT_LOG_EVENT_UNFILTERED' and isAddonLoaded then
     -- Update kill counts when combat events occur
     UpdateStatistics()
-  elseif event == 'PLAYER_LEVEL_UP' then
+  elseif event == 'PLAYER_LEVEL_UP' and isAddonLoaded then
     -- Update XP when leveling up
     UpdateStatistics()
-  elseif event == 'ADDON_LOADED' then
+  elseif event == 'ADDON_LOADED' and addonName == 'UltraHardcore' then
     -- Check setting when addon loads
+    isAddonLoaded = true
     CheckAddonEnabled()
   end
 end)

--- a/UltraHardcore.lua
+++ b/UltraHardcore.lua
@@ -25,8 +25,9 @@ UltraHardcore:RegisterEvent('CHAT_MSG_SYSTEM') -- Needed for duel winner and los
 
 -- 🟢 Event handler to apply all funcitons on login
 UltraHardcore:SetScript('OnEvent', function(self, event, ...)
-  if event == 'PLAYER_ENTERING_WORLD' or event == 'ADDON_LOADED' then
+  if event == 'ADDON_LOADED' and addonName == 'UltraHardcore' then
     LoadDBData()
+  elseif event == 'PLAYER_ENTERING_WORLD' then
     HidePlayerMapIndicators()
     ShowWelcomeMessage()
     ShowVersionUpdateDialog()


### PR DESCRIPTION
LoadDB is getting called before the addon is loaded. I'm not sure how dangerous that is, but this appears to work around the problem. 

I added prints in LoadDB() to see that on existing characters we were calling this before UltraHardcoreDB was loaded and we would return an empty table.

Also, optimized GetCurrentCharacterStats so that it doesn't copy the table.