### PR TITLE
feat: add one time resource explainer

### DIFF
--- a/Functions/PatchNotes.lua
+++ b/Functions/PatchNotes.lua
@@ -13,6 +13,8 @@ PATCH_NOTES = {
       '',
       'UI IMPROVEMENTS:',
       '• Reset on screen statistics command: "/uhcrs" or "/uhcstatsreset"',
+      '• Added one time Resource Tracking Explainer',
+      '  • The addon will show a message on the screen explaining how to use the resource tracking feature when the minimap is hidden.',
       '',
       'BUG FIXES:',
       '• Fix: Route planner added to xp gained tracker',

--- a/Functions/ResourceTrackingExplainer.lua
+++ b/Functions/ResourceTrackingExplainer.lua
@@ -1,0 +1,73 @@
+local explainerOpen = false
+
+local function CreateResourceTrackingExplainerFrame()
+  local frame = CreateFrame('Frame', 'UltraHardcoreResourceTrackingExplainer', UIParent, 'BackdropTemplate')
+  frame:SetSize(360, 170)
+  frame:SetPoint('CENTER')
+  frame:SetFrameStrata('DIALOG')
+  frame:SetBackdrop({
+    bgFile = 'Interface\\DialogFrame\\UI-DialogBox-Background',
+    edgeFile = 'Interface\\DialogFrame\\UI-DialogBox-Border',
+    tile = true,
+    tileSize = 32,
+    edgeSize = 16,
+    insets = {
+      left = 8,
+      right = 8,
+      top = 8,
+      bottom = 8,
+    },
+  })
+  frame:SetMovable(true)
+  frame:EnableMouse(true)
+  frame:RegisterForDrag('LeftButton')
+  frame:SetScript('OnDragStart', frame.StartMoving)
+  frame:SetScript('OnDragStop', frame.StopMovingOrSizing)
+  frame:Hide()
+
+  local title = frame:CreateFontString(nil, 'OVERLAY', 'GameFontHighlight')
+  title:SetPoint('TOP', frame, 'TOP', 0, -16)
+  title:SetWidth(320)
+  title:SetJustifyH('CENTER')
+  local font, _, flags = title:GetFont()
+  title:SetFont(font, 16, flags)
+  title:SetTextColor(1, 1, 0)
+  title:SetText('Resource Tracking')
+
+  local icon = frame:CreateTexture(nil, 'ARTWORK')
+  icon:SetSize(24, 24)
+  icon:SetPoint('TOP', frame, 'TOP', 0, -42)
+  icon:SetTexture('Interface\\MINIMAP\\TRACKING\\FindHerbs')
+
+  local message = frame:CreateFontString(nil, 'OVERLAY', 'GameFontHighlight')
+  message:SetPoint('TOP', frame, 'TOP', 0, -74)
+  message:SetWidth(300)
+  message:SetJustifyH('CENTER')
+  local mfont, _, mflags = message:GetFont()
+  message:SetFont(mfont, 12, mflags)
+  message:SetText("Quick tip: When your minimap is hidden, casting a tracking spell will briefly highlight nearby resources on your screen (about 5 seconds).")
+
+  local closeButton = CreateFrame('Button', nil, frame, 'UIPanelButtonTemplate')
+  closeButton:SetSize(120, 24)
+  closeButton:SetPoint('BOTTOM', frame, 'BOTTOM', 0, 20)
+  closeButton:SetText('Got it')
+  closeButton:SetScript('OnClick', function()
+    SaveDBData('shownResourceTrackingExplainer', true)
+    explainerOpen = false
+    frame:Hide()
+  end)
+
+  return frame
+end
+
+function ShowResourceTrackingExplainer()
+  if explainerOpen then return end
+  if UltraHardcoreDB and UltraHardcoreDB.shownResourceTrackingExplainer then return end
+  if not GLOBAL_SETTINGS or not GLOBAL_SETTINGS.hideMinimap then return end
+
+  explainerOpen = true
+  local frame = _G.UltraHardcoreResourceTrackingExplainer or CreateResourceTrackingExplainerFrame()
+  frame:Show()
+end
+
+

--- a/PATCH_NOTES.md
+++ b/PATCH_NOTES.md
@@ -14,6 +14,8 @@
 ### UI Improvements
 
 - Reset on screen statistics command: "/uhcrs" or "/uhcstatsreset"
+- Added one time Resource Tracking Explainer
+  - The addon will show a message on the screen explaining how to use the resource tracking feature when the minimap is hidden.
 
 ### Bug Fixes
 

--- a/UltraHardcore.lua
+++ b/UltraHardcore.lua
@@ -38,6 +38,7 @@ UltraHardcore:SetScript('OnEvent', function(self, event, ...)
       GLOBAL_SETTINGS.hideMinimap or false,
       GLOBAL_SETTINGS.showClockEvenWhenMapHidden or false
     )
+    ShowResourceTrackingExplainer()
     SetTargetFrameDisplay(
       GLOBAL_SETTINGS.hideTargetFrame or false,
       GLOBAL_SETTINGS.completelyRemoveTargetFrame or false

--- a/UltraHardcore.toc
+++ b/UltraHardcore.toc
@@ -25,6 +25,7 @@ Functions/WelcomeMessage.lua
 Functions/PatchNotes.lua
 Functions/PatchNotesDisplay.lua
 Functions/VersionUpdateDialog.lua
+Functions/ResourceTrackingExplainer.lua
 Functions/HidePlayerCastBar.lua
 Functions/JoinParty.lua
 Functions/SetActionBarVisibility.lua


### PR DESCRIPTION
### Summary

- Add a one time dialog on load to explain how resource gathering works in ultra

### Changes

- shownResourceTrackingExplainer added to db variables
- Dialog for showing if this value is true

### Screenshots / Video (optional)

N/A

### Testing Steps (in-game)

1. How to enable/trigger the feature (commands, settings, reloads).
2. Test matrix:
   - Reload UI (/reload)
3. Expected result:
   - See dialog one time

### UI/UX

N/A

### Localization

N/A

### Docs & Patch Notes

- PATCH_NOTES entry needed?

### Checklist

- [x] Verified in-game on Classic Era
- [x] Tested after reload (/reload) with no LUA errors
- [x] No combat lockdown/taint issues (entering/leaving combat)
- [x] Reasonable performance (no excessive timers/ticks)
- [x] Docs and/or PATCH_NOTES updated where needed
- [x] Screenshots/video added when helpful

