### PR TITLE
fix(StatisticsTab.lua): added a grace period for verification

### DIFF
--- a/Settings/StatisticsTab.lua
+++ b/Settings/StatisticsTab.lua
@@ -171,14 +171,28 @@ function InitializeStatisticsTab()
   legitStatusLine3:SetShadowColor(0, 0, 0, 0.8)
   legitStatusLine3:SetTextColor(0.7, 0.7, 0.7)
   local function UpdateLegitStatusText()
-    local xpWithoutAddon = 1
+    local xpWithoutAddon = 0
+    local xpWithAddon = 0
+    
     if CharacterStats and CharacterStats.ReportXPWithoutAddon then
       local reported = CharacterStats:ReportXPWithoutAddon()
       if type(reported) == 'number' then
         xpWithoutAddon = reported
       end
     end
+    
+    if CharacterStats and CharacterStats.GetStat then
+      xpWithAddon = CharacterStats:GetStat('xpGWA') or 0
+    end
+    
+    local totalXP = xpWithAddon + xpWithoutAddon
+    local xpWithAddonPercent = 100
+    
+    if totalXP > 0 then
+      xpWithAddonPercent = (xpWithAddon / totalXP) * 100
+    end
 
+    -- Three tiers: 100% = perfect (green), 98-99.99% = tainted (yellow), <98% = failed (red)
     if xpWithoutAddon == 0 then
       legitStatusLine1:SetText('Verified Ultra status')
       legitStatusLine2:SetText('No XP was gained while the addon was inactive')
@@ -186,6 +200,13 @@ function InitializeStatisticsTab()
       legitStatusLine2:SetTextColor(0.7, 1.0, 0.7)
       legitStatusIcon:SetVertexColor(0.2, 0.95, 0.3)
       legitStatusLine3:SetTextColor(0.7, 1.0, 0.7)
+    elseif xpWithAddonPercent >= 98 then
+      legitStatusLine1:SetText('Tainted Ultra status')
+      legitStatusLine2:SetText('Small amount of XP gained while addon was inactive')
+      legitStatusLine1:SetTextColor(1.0, 0.82, 0.0)
+      legitStatusLine2:SetTextColor(0.9, 0.9, 0.7)
+      legitStatusIcon:SetVertexColor(1.0, 0.82, 0.0)
+      legitStatusLine3:SetTextColor(0.9, 0.9, 0.7)
     else
       legitStatusLine1:SetText('Ultra status failed verification')
       legitStatusLine2:SetText('XP was gained while the addon was inactive')


### PR DESCRIPTION
added a grace period for verification saying 'tainted' if the addon was turned off while gaining XP and a 'perfect' status if addon was never turned off. failed for everything below 98% xp gained.

### Summary

- adjusted the values for verification

### Changes

- changed the StatisticsTab.lua
- added a grace period for this to make 98% of xp gained without addon to be tainted and everything below that a failed verification status.

### Screenshots / Video (optional)

N/A

### Testing Steps (in-game)

1. Test matrix:
   - Reload UI (/reload)
2. Expected result:
   - On Statistics tab you could now see the three different statuses.

### UI/UX

N/A

### Localization

N/A

### Docs & Patch Notes

- PATCH_NOTES haven't adjusted this, because might not be implemented

### Checklist

- [x] Verified in-game on Classic Era
- [x] Tested after reload (/reload) with no LUA errors
- [x] No combat lockdown/taint issues (entering/leaving combat)
- [x] Reasonable performance (no excessive timers/ticks)
- [ ] Docs and/or PATCH_NOTES updated where needed
- [ ] Screenshots/video added when helpful

