### PR TITLE
Remove UpdateStatistics call that is being executed before events

### DIFF
--- a/Functions/Overlays/MainScreenStatistics.lua
+++ b/Functions/Overlays/MainScreenStatistics.lua
@@ -645,9 +645,6 @@ statsFrame:SetScript('OnEvent', function(self, event, ...)
   end
 end)
 
--- Initial update
-UpdateStatistics()
-
 -- Slash command to reset statistics frame to its saved position
 local function ResetStatsFrameToSavedPosition()
   if not UltraHardcoreDB then


### PR DESCRIPTION
### Summary

Regression.  

This call was removed in https://github.com/BoojiB/UltraHardcore/commit/69a7ec3b31dfbce29209d180639a9593bea15182 but got re-added with another merge.

### Changes

Removed the call that is getting run before the addon is fully loaded. 

### Testing Steps (in-game)

1. Can only verify by adding debug output.

I modified LoadDB() to show who called it when the DB was not ready or available.

```
function LoadDBData()
  if not UltraHardcoreDB then
    print(debugstack())
    UltraHardcoreDB = {} -- Ensure the table exists
  end
...
```


- [x] Verified in-game on Classic Era
- [x] Tested after reload (/reload) with no LUA errors
- [x] No combat lockdown/taint issues (entering/leaving combat)
- [x] Reasonable performance (no excessive timers/ticks)
- [x] Docs and/or PATCH_NOTES updated where needed
- [x] Screenshots/video added when helpful

