### PR TITLE
Allow Using Raid Frame for Party

### DIFF
--- a/Functions/HidePartyInformation.lua
+++ b/Functions/HidePartyInformation.lua
@@ -16,8 +16,6 @@ PARTY_MEMBER_SUBFRAMES_TO_HIDE =
   }
 
 function SetPartyFramesInfo(hideGroupHealth)
-  ForcePartyFrames()
-
   if hideGroupHealth then
     for n = 1, 5 do
       SetPartyFrameInfo(n)
@@ -341,23 +339,6 @@ local function HookCompactRaidHealthHiding()
   hooksecurefunc('CompactUnitFrame_UpdateAll', hideFromUpdate)
 end
 
-function ForcePartyFrames()
-  if InCombatLockdown() then
-    -- If in combat, queue the CVar change for later
-    C_Timer.After(0.1, function()
-      if not InCombatLockdown() then
-        ForcePartyFrames()
-      end
-    end)
-  else
-    -- Only change the CVar if it's not already set to 0
-    local currentValue = GetCVar('useCompactPartyFrames')
-    if currentValue ~= '0' then
-      SetCVar('useCompactPartyFrames', 0)
-    end
-  end
-end
-
 -- Ensure that party frames are always configured
 local frame = CreateFrame('Frame')
 frame:RegisterEvent('CVAR_UPDATE')
@@ -381,7 +362,6 @@ frame:SetScript('OnEvent', function(self, event, arg1)
   if GLOBAL_SETTINGS.hideGroupHealth then
     -- Only apply changes when not in combat lockdown
     if not InCombatLockdown() then
-      ForcePartyFrames()
       -- Apply styling to all party frames
       for n = 1, 5 do
         SetPartyFrameInfo(n)
@@ -393,7 +373,6 @@ frame:SetScript('OnEvent', function(self, event, arg1)
       -- If in combat, defer the changes
       C_Timer.After(0.1, function()
         if not InCombatLockdown() and GLOBAL_SETTINGS.hideGroupHealth then
-          ForcePartyFrames()
           for n = 1, 5 do
             SetPartyFrameInfo(n)
           end

--- a/Functions/SetPartyHealthIndicator.lua
+++ b/Functions/SetPartyHealthIndicator.lua
@@ -804,7 +804,8 @@ partyHealthFrame:RegisterEvent('ADDON_LOADED')
 partyHealthFrame:SetScript('OnEvent', function(self, event, unit)
   if event == 'UNIT_HEALTH_FREQUENT' or event == 'UNIT_HEALTH' then
     -- Raid member health updates
-    if unit and unit:match('^raid%d+$') then
+    local raidFrameInParty = GetCVar('useCompactPartyFrames')
+    if unit and (unit:match('^raid%d+$') or raidFrameInParty) then
       if GLOBAL_SETTINGS and (GLOBAL_SETTINGS.hideGroupHealth or false) then
         UpdateRaidHealthIndicatorForUnit(unit)
       end


### PR DESCRIPTION
(edit: per the feedback from BonniesDad in discord, remove the whole ForcePartyFrame logic, hence no need for a new option).

Now since we support hiding information in the Raid Frame, it makes sense to allow players to use Raid Frame for Parties.

### Summary

This PR allows players to use the Ultra Raid Frame for parties. Some of the players including me are more comfortable with raid frame even in parties (e.g. see party member's debuff/buff etc).

### Changes

Don't force using party frame if players have select "Use Raid-Style party Frames" in the game interface.


### Screenshots / Video (optional)

### Testing Steps (in-game)

1.  Join a party and then select and unselect "Use Raid-Style Party Frames" in the game option (in "Interface").

2. Test matrix:
   - Reload UI (/reload)
   - Enter/leave combat
   - Grouped vs solo
   - Different classes/resources (rage/energy/mana)
   - With and without related settings enabled
3. Expected result:
   - The player will see a Raid frame for the party.

### UI/UX

### Localization

### Docs & Patch Notes

- Allow player to use Ultra Raid-style Frame in parties

### Checklist

- [x] Verified in-game on Classic Era
- [x] Tested after reload (/reload) with no LUA errors
- [ ] No combat lockdown/taint issues (entering/leaving combat)
- [x] Reasonable performance (no excessive timers/ticks)
- [x] Docs and/or PATCH_NOTES updated where needed
- [ ] Screenshots/video added when helpful

