### PR TITLE
Fix/uhc verify party members

### DIFF
--- a/Functions/SetActionBarVisibility.lua
+++ b/Functions/SetActionBarVisibility.lua
@@ -89,7 +89,14 @@ f:RegisterEvent('PLAYER_ENTERING_WORLD') -- ensure state correct on reload/login
 f:SetScript('OnEvent', function(self, event, ...)
   if event == 'UNIT_AURA' then
     OnPlayerUnitAuraEvent(self, ...)
-  elseif event == 'PLAYER_REGEN_DISABLED' or event == 'PLAYER_REGEN_ENABLED' or event == 'PLAYER_ENTERING_WORLD' then
+  elseif event == 'PLAYER_REGEN_DISABLED' or event == 'PLAYER_REGEN_ENABLED' then
+    -- Defer action bar visibility changes when entering/leaving combat to avoid protected frame errors
+    if C_Timer and C_Timer.After then
+      C_Timer.After(0.5, function()
+        SetActionBarVisibility(GLOBAL_SETTINGS.hideActionBars)
+      end)
+    end
+  elseif event == 'PLAYER_ENTERING_WORLD' then
     SetActionBarVisibility(GLOBAL_SETTINGS.hideActionBars)
   elseif event == 'PLAYER_CONTROL_GAINED' or event == 'PLAYER_CONTROL_LOST' then
     -- We need a slight delay after getting on a taxi before UnitOnTaxi will return true

--- a/Functions/VerifyParty.lua
+++ b/Functions/VerifyParty.lua
@@ -6,22 +6,43 @@ local verificationRequestTime = 0
 local isWaitingForResponses = false
 local lastPartyMembers = {}
 local lastAutoVerifyTime = 0
-local AUTO_VERIFY_THROTTLE = 5 -- Minimum seconds between automatic verifications
+local AUTO_VERIFY_THROTTLE = 5
+local wasInGroup = false
 
--- Function to get current party member names
+local yellowTextColour = '|cffffd000'
+local greenTextColour = '|cff33F24C'
+local redTextColour = '|cffFF4444'
+
+-- Helper to convert member list to normalized set
+local function BuildMemberSet(members)
+  local memberSet = {}
+  for _, name in ipairs(members) do
+    local normalized = NormalizeName(name)
+    if normalized then
+      memberSet[normalized] = true
+    end
+  end
+  return memberSet
+end
+
+-- Function to get current party member names (only online members)
 local function GetCurrentPartyMembers()
   local members = {}
   if IsInRaid() then
     for i = 1, GetNumGroupMembers() do
-      local name = GetRaidRosterInfo(i)
-      if name then
+      local name, _, _, _, _, _, _, online = GetRaidRosterInfo(i)
+      if name and online then
         table.insert(members, name)
       end
     end
   elseif IsInGroup() then
-    for i = 1, GetNumGroupMembers() do
-      local name = UnitName('party' .. i)
-      if name then
+    --[[ Because GetNumGroupMembers() includes the player as well, party units are party1-party4 (not including yourself) ]]--
+    local numMembers = GetNumGroupMembers()
+    for i = 1, numMembers - 1 do  -- -1 because the count includes yourself but units don't
+      local unit = 'party' .. i
+      local name = UnitName(unit)
+      local isOnline = UnitIsConnected(unit)
+      if name and isOnline then
         table.insert(members, name)
       end
     end
@@ -104,17 +125,19 @@ local function GetPlayerLegitimacyStatus(presetLevel)
   end
 end
 
+-- Helper to get the appropriate chat channel
+local function GetGroupChannel()
+  return IsInRaid() and 'RAID' or 'PARTY'
+end
+
 -- This sends a verification request to party members
 local function SendVerificationRequest()
-  local channel = IsInRaid() and 'RAID' or 'PARTY'
   if C_ChatInfo and C_ChatInfo.SendAddonMessage then
-    C_ChatInfo.SendAddonMessage(ADDON_PREFIX, 'REQUEST', channel)
+    C_ChatInfo.SendAddonMessage(ADDON_PREFIX, 'REQUEST', GetGroupChannel())
   end
 end
 
 local function SendVerificationResponse()
-  local channel = IsInRaid() and 'RAID' or 'PARTY'
-
   local presetLevel = DeterminePresetLevel(GLOBAL_SETTINGS)
   local isLegit, presetName = GetPlayerLegitimacyStatus(presetLevel)
   
@@ -124,29 +147,37 @@ local function SendVerificationResponse()
   local message = presetStr .. ':' .. legitStr
   
   if C_ChatInfo and C_ChatInfo.SendAddonMessage then
-    C_ChatInfo.SendAddonMessage(ADDON_PREFIX, message, channel)
+    C_ChatInfo.SendAddonMessage(ADDON_PREFIX, message, GetGroupChannel())
+  end
+end
+
+-- Function to print verification status for a single player's data
+local function PrintVerificationStatus(name, data)
+  local preset = data.preset or 'None'
+  local isLegit = data.legit == true
+  local isOk = '|TInterface\\AddOns\\UltraHardcore\\Textures\\01_bonnie_light.png:0|t'
+  local isTainted = '|TInterface\\AddOns\\UltraHardcore\\Textures\\02_bonnie_recommended.png:0|t'
+  local isFailed = '|TInterface\\AddOns\\UltraHardcore\\Textures\\03_bonnie_extreme.png:0|t'
+  
+  if isLegit then
+    print(yellowTextColour .. '[UHC]|r ' .. greenTextColour .. '[' .. isOk .. ' - OK]|r ' .. name .. greenTextColour .. ' - Certified ' .. preset .. ' Ultra|r')
+  elseif preset ~= 'None' then
+    print(yellowTextColour .. '[UHC]|r ' .. redTextColour .. '[' .. isTainted .. ' - Tainted]|r ' .. name .. yellowTextColour .. ' - ' .. preset .. ' settings but not legitimate|r')
+  else
+    print(yellowTextColour .. '[UHC]|r ' .. redTextColour .. '[' .. isFailed .. ' - Failed]|r ' .. name .. redTextColour .. ' - Not using UHC addon or not using a preset|r')
   end
 end
 
 local function DisplayVerificationResults()
   local playerName = UnitName('player')
   
-  print('|cffffd000[UHC]|r Party Member Verification Results:')
-  print('|cffffd000[UHC]|r ' .. string.rep('-', 50))
+  print(yellowTextColour .. '[UHC]|r Party Member Verification Results:')
+  print(yellowTextColour .. '[UHC]|r ' .. string.rep('-', 50))
   
   local hasResponses = false
   for name, data in pairs(partyVerificationData) do
     hasResponses = true
-    local preset = data.preset or 'None'
-    local isLegit = data.legit == true
-    
-    if isLegit then
-      print('|cffffd000[UHC]|r |cff33F24C[OK]|r ' .. name .. ' - Certified ' .. preset .. ' Ultra')
-    elseif preset ~= 'None' then
-      print('|cffffd000[UHC]|r |cffFF4444[X]|r ' .. name .. ' - ' .. preset .. ' settings but not legitimate')
-    else
-      print('|cffffd000[UHC]|r |cffFF4444[X]|r ' .. name .. ' - Not using UHC addon or not using a preset')
-    end
+    PrintVerificationStatus(name, data)
   end
 
   -- Check for members who didn't respond
@@ -161,14 +192,14 @@ local function DisplayVerificationResults()
   end
   
   if #nonResponders > 0 then
-    print('|cffffd000[UHC]|r')
-    print('|cffffd000[UHC]|r |cffFFAA00[!]|r No response from: ' .. table.concat(nonResponders, ', '))
-    print('|cffffd000[UHC]|r These members may not have the UHC addon installed.')
+    print(yellowTextColour .. '[UHC]|r')
+    print(yellowTextColour .. '[UHC]|r |cffFFAA00[!]|r No response from: ' .. table.concat(nonResponders, ', '))
+    print(yellowTextColour .. '[UHC]|r These members may not have the UHC addon installed.')
   end
   
   if not hasResponses and #nonResponders == 0 then
-    print('|cffffd000[UHC]|r')
-    print('|cffffd000[UHC]|r Note: No other party members detected or responded.')
+    print(yellowTextColour .. '[UHC]|r')
+    print(yellowTextColour .. '[UHC]|r Note: No other party members detected or responded.')
   end
 end
 
@@ -177,35 +208,41 @@ local function DisplaySinglePlayerVerification(targetName)
   local data = partyVerificationData[targetName]
   
   if data then
-    local preset = data.preset or 'None'
-    local isLegit = data.legit == true
-    
-    print('|cffffd000[UHC]|r Verification Result for ' .. targetName .. ':')
-    print('|cffffd000[UHC]|r ' .. string.rep('-', 50))
-    
-    if isLegit then
-      print('|cffffd000[UHC]|r |cff33F24C[OK]|r ' .. targetName .. ' - Certified ' .. preset .. ' Ultra')
-    elseif preset ~= 'None' then
-      print('|cffffd000[UHC]|r |cffFF4444[X]|r ' .. targetName .. ' - ' .. preset .. ' settings but not legitimate')
-    else
-      print('|cffffd000[UHC]|r |cffFF4444[X]|r ' .. targetName .. ' - Not using UHC addon or not using a preset')
-    end
+    print(yellowTextColour .. '[UHC]|r Verification Result for ' .. targetName .. ':')
+    print(yellowTextColour .. '[UHC]|r ' .. string.rep('-', 50))
+    PrintVerificationStatus(targetName, data)
   else
-    print('|cffffd000[UHC]|r |cffFFAA00[!]|r No response from ' .. targetName)
-    print('|cffffd000[UHC]|r They may not have the UHC addon installed or are not in your group.')
+    print(yellowTextColour .. '[UHC]|r' .. redTextColour .. '[!]|r No response from ' .. targetName .. '|r')
+    print(yellowTextColour .. '[UHC]|r They may not have the UHC addon installed or are not in your group.')
+  end
+end
+
+-- Helper to start verification process
+local function StartVerification(targetPlayer)
+  verificationRequestTime = GetTime()
+  isWaitingForResponses = true
+  SendVerificationRequest()
+  
+  if targetPlayer then
+    print(yellowTextColour .. '[UHC]|r Requesting verification from ' .. targetPlayer .. '...')
+    C_Timer.After(2, function()
+      isWaitingForResponses = false
+      DisplaySinglePlayerVerification(targetPlayer)
+    end)
+  else
+    print(yellowTextColour .. '[UHC]|r Requesting verification from party members...')
+    C_Timer.After(2, function()
+      isWaitingForResponses = false
+      DisplayVerificationResults()
+    end)
   end
 end
 
 -- Function to verify a specific player by name
 local function VerifySpecificPlayer(playerName)
-  if not IsInGroup() then
-    print('|cffffd000[UHC]|r You are not in a party or raid.')
-    return
-  end
-
   local normalizedTarget = NormalizeName(playerName)
   if not normalizedTarget then
-    print('|cffffd000[UHC]|r Invalid player name.')
+    print(yellowTextColour .. '[UHC]|r' .. redTextColour .. ' Invalid player name.|r')
     return
   end
 
@@ -220,89 +257,73 @@ local function VerifySpecificPlayer(playerName)
   end
 
   if not isInParty then
-    print('|cffffd000[UHC]|r ' .. normalizedTarget .. ' is not in your party or raid.')
+    print(yellowTextColour .. '[UHC]|r ' .. normalizedTarget .. redTextColour .. ' is not in your party or raid.|r')
     return
   end
 
-  -- Reset verification data for this specific player
   partyVerificationData[normalizedTarget] = nil
-  verificationRequestTime = GetTime()
-  isWaitingForResponses = true
-  
-  SendVerificationRequest()
-  
-  print('|cffffd000[UHC]|r Requesting verification from ' .. normalizedTarget .. '...')
-  
-  C_Timer.After(2, function()
-    isWaitingForResponses = false
-    DisplaySinglePlayerVerification(normalizedTarget)
-  end)
+  StartVerification(normalizedTarget)
 end
 
--- Main function to verify UHC party members
+
 function VerifyUhcPartyMembers(args)
+  if not IsInGroup() then
+    print(yellowTextColour .. '[UHC]|r You are not in a party or raid.')
+    return
+  end
+
   if args and args ~= '' then
     VerifySpecificPlayer(args)
     return
   end
 
-  -- Check if player is in a group
-  if not IsInGroup() then
-    print('|cffffd000[UHC]|r You are not in a party or raid.')
-    return
-  end
-
-  -- Reset verification data
   partyVerificationData = {}
-  verificationRequestTime = GetTime()
-  isWaitingForResponses = true
-  
-  SendVerificationRequest()
-  
-  print('|cffffd000[UHC]|r Requesting verification from party members...')
-  
-  C_Timer.After(2, function()
-    isWaitingForResponses = false
-    DisplayVerificationResults()
-  end)
+  StartVerification()
 end
 
 -- Function to detect new party members and auto-verify
 local function CheckForNewPartyMembers()
-  if not IsInGroup() then
+  local currentlyInGroup = IsInGroup()
+  
+  if not currentlyInGroup then
     lastPartyMembers = {}
+    wasInGroup = false
     return
   end
 
   local currentMembers = GetCurrentPartyMembers()
-  local currentMemberSet = {}
+  local currentMemberSet = BuildMemberSet(currentMembers)
+  local justJoinedGroup = not wasInGroup and currentlyInGroup
   
-  for _, name in ipairs(currentMembers) do
-    local normalized = NormalizeName(name)
-    if normalized then
-      currentMemberSet[normalized] = true
-    end
-  end
- 
+  -- Find members who are in current party but weren't in last party
   local newMembers = {}
-  for memberName, _ in pairs(currentMemberSet) do
-    if not lastPartyMembers[memberName] then
-      table.insert(newMembers, memberName)
+  if next(lastPartyMembers) ~= nil then
+    for memberName, _ in pairs(currentMemberSet) do
+      if not lastPartyMembers[memberName] then
+        table.insert(newMembers, memberName)
+      end
     end
   end
   
+  -- Update state
   lastPartyMembers = currentMemberSet
+  wasInGroup = currentlyInGroup
 
-  if #newMembers > 0 then
+  -- Determine if verification is needed
+  local shouldVerify = #newMembers > 0 or (justJoinedGroup and next(currentMemberSet) ~= nil)
+  
+  if shouldVerify then
     local currentTime = GetTime()
     if currentTime - lastAutoVerifyTime >= AUTO_VERIFY_THROTTLE then
       lastAutoVerifyTime = currentTime
       
-      -- Display notification about new members
-      if #newMembers == 1 then
-        print('|cffffd000[UHC]|r ' .. newMembers[1] .. ' joined the party. Verifying...')
+      -- Display appropriate notification
+      if justJoinedGroup then
+        print(yellowTextColour .. '[UHC]|r Joined party.' .. yellowTextColour .. ' Verifying members...|r')
+      elseif #newMembers == 1 then
+        print(yellowTextColour .. '[UHC]|r ' .. newMembers[1] .. ' joined the party.' .. yellowTextColour .. ' Verifying...|r')
       else
-        print('|cffffd000[UHC]|r ' .. #newMembers .. ' new members joined the party. Verifying...')
+        print(yellowTextColour .. '[UHC]|r ' .. #newMembers .. ' new members joined the party.' .. yellowTextColour .. ' Verifying...|r')
       end
 
       C_Timer.After(0.5, function()
@@ -316,18 +337,35 @@ if C_ChatInfo and C_ChatInfo.RegisterAddonMessagePrefix then
   C_ChatInfo.RegisterAddonMessagePrefix(ADDON_PREFIX)
 end
 
+-- Initialize the party state immediately
+local function InitializePartyState()
+  wasInGroup = IsInGroup()
+  if wasInGroup then
+    local members = GetCurrentPartyMembers()
+    lastPartyMembers = BuildMemberSet(members)
+  end
+end
+
 local verifyFrame = CreateFrame('Frame')
 verifyFrame:RegisterEvent('CHAT_MSG_ADDON')
 verifyFrame:RegisterEvent('GROUP_ROSTER_UPDATE')
+verifyFrame:RegisterEvent('PLAYER_ENTERING_WORLD')
 
 verifyFrame:SetScript('OnEvent', function(self, event, prefix, message, channel, sender)
-  if event == 'GROUP_ROSTER_UPDATE' then
-    -- Check for new party members when roster changes
-    CheckForNewPartyMembers()
+  if event == 'PLAYER_ENTERING_WORLD' then
+    InitializePartyState()
     return
   end
   
-  if event == 'CHAT_MSG_ADDON' and prefix == ADDON_PREFIX then
+  if event == 'GROUP_ROSTER_UPDATE' then
+    --[[ Check for new party members when roster changes  
+         I had to add a small delay, because sometimes unit info isn't populated immediately ]]--
+    C_Timer.After(0.5, function()
+      CheckForNewPartyMembers()
+    end)
+    return
+  end
+  
   if event == 'CHAT_MSG_ADDON' and prefix == ADDON_PREFIX then
     local senderName = NormalizeName(sender)
     if not senderName then


### PR DESCRIPTION
…/uhcverify <playerName>` and check a party player if they're still legit verified. Also this will fire a check when a new member joins the party. Added a 5 second grace period to avoid doublechecks too often

### Summary

- optimized the `/uhcverify` command

### Screenshots / Video (optional)

after someone invited to party:
<img width="1116" height="539" alt="image" src="https://github.com/user-attachments/assets/5078daf0-79df-4044-96d8-d9d87c9b47dc" />

when using `/uhcverify <name>`:
<img width="799" height="151" alt="image" src="https://github.com/user-attachments/assets/a5ee9fd8-c2ef-41ed-a0c1-dad235b3d91b" />

<img width="752" height="193" alt="image" src="https://github.com/user-attachments/assets/a9dbe0cc-dbd5-4dc0-8b7d-0bb6c86b913f" />

<img width="1058" height="189" alt="image" src="https://github.com/user-attachments/assets/d6a36613-3bd1-4f83-8bc9-97d9f185bcea" />


### Testing Steps (in-game)

1. Test matrix:
   - Reload UI (/reload)
   - use `/uhcverify` for party verification
   - use `/uhcverify <name>` to verify a specific party member
   - when joining a party a check will happen. 
  >**⚠️ WARNING: This might need optimization!**

2. Expected result:
   - You should see a check in the chat that prints if people are verified or not.
   - marked different levels with the lovely bonnie icons Vivi made