### PR TITLE
[Bug Fix] XP gained is properly tracked during level up (and other fixes)

### DIFF
--- a/Functions/Statistics/TrackXPPerSetting.lua
+++ b/Functions/Statistics/TrackXPPerSetting.lua
@@ -41,6 +41,27 @@ local settingToXPVariable = {
 local sessionStartXP = nil
 local lastXPUpdate = nil
 local lastXPValue = nil
+local xpTrackingInitialized = false
+
+local function InitializeXpGainedWithAddon(playerLevel, lastXPValue, stats)
+  if lastXPValue == 0 and playerLevel > 1 then
+    -- This shouldn't happen but just in case, don't run until later
+    return false
+  end
+
+  CharacterStats:UpdateStat("xpTotal", CharacterStats:CalculateTotalXPGained())
+
+  local shouldRecalculate = CharacterStats:ShouldRecalculateXPGainedWithAddon(stats)
+
+  if playerLevel == 1 and lastXPValue == 0 then
+    CharacterStats:UpdateStat("xpTotal", 0)
+    CharacterStats:UpdateStat("xpGWA", 0)
+    CharacterStats:UpdateStat("xpGWOA", 0)
+  elseif shouldRecalculate  == true then
+    CharacterStats:ResetXPGainedWithAddon(playerLevel, true)
+  end
+  return true
+end
 
 -- Function to initialize XP tracking
 local function InitializeXPTracking()
@@ -48,27 +69,31 @@ local function InitializeXPTracking()
   -- Start tracking from current XP for this session
   lastXPValue = UnitXP("player")
   lastXPUpdate = GetTime()
-  -- Frequently player XP reports as 0 when entering the game, wait a sec and retry
-  if lastXPValue == 0 and playerLevel > 1 then
-    C_Timer.After(1.0, function() 
-      lastXPValue = UnitXP("player")
-      lastXPUpdate = GetTime()
-    end)
-  end
-  -- Do this to preload all stats
-  local stats = CharacterStats:GetCurrentCharacterStats()
-  CharacterStats:UpdateStat("XpTotal", CharacterStats:CalculateTotalXPGained())
 
-  if stats.xpGWA == nil and lastXPValue > 0 then
-    -- It looks like sometimes player XP is reported as 0 as you enter the world
-    CharacterStats:ResetXPGainedWithAddon(true)
+  -- This code only needs to run once either on login or reload
+  if xpTrackingInitialized ~= true then
+    local stats = CharacterStats:GetCurrentCharacterStats()
+    InitializeXpGainedWithAddon(playerLevel, lastXPValue, stats)
+    xpTrackingInitialized = true
   end
 end
 
 -- Function to update XP tracking for each setting
-local function UpdateXPTracking()
-  local currentXP = UnitXP("player")
+local function UpdateXPTracking(levelUp)
+  if levelUp == nil then levelUp = false end
+
+  local currentXP = 0
   local currentTime = GetTime()
+
+  if levelUp then
+    -- The game does not report the correct XP amount on level up, so we calculate it
+    local newLevel = UnitLevel("player")
+    local xpThisLevel = TotalXPTable[newLevel]
+    currentXP = xpThisLevel
+  else
+    currentXP = UnitXP("player")
+  end
+
   
   -- Only update if XP has increased and enough time has passed (prevent spam)
   if currentXP > lastXPValue and (currentTime - lastXPUpdate) > 1 then
@@ -90,11 +115,17 @@ local function UpdateXPTracking()
       end
     end
     
-    -- NOTE: We do NOT update the general "without addon" tracking here
-    -- That should be handled by the original XPGainedTracker.lua system
-    
-    lastXPValue = currentXP
-    lastXPUpdate = currentTime
+    if levelUp then
+      -- We just leveled up so our UnitXP is going to be only the amount in excess of the level up threshhold
+      -- Leveling up means our UnitXP is effectively 0, so set that value
+      --
+      -- Do not reset the time because UpdateXPTracking is going to fire again immediately
+      -- after PLAYER_LEVEL_UP and we want to count that XP
+      lastXPValue = 0
+    else
+      lastXPValue = currentXP
+      lastXPUpdate = currentTime
+    end
   end
 end
 
@@ -122,14 +153,21 @@ xpTrackingFrame:RegisterEvent("ADDON_LOADED")
 
 xpTrackingFrame:SetScript("OnEvent", function(self, event, ...)
   if event == "PLAYER_XP_UPDATE" then
-    UpdateXPTracking()
+    UpdateXPTracking(false)
   elseif event == "PLAYER_LEVEL_UP" then
     -- Reset tracking when leveling up
-    InitializeXPTracking()
+    UpdateXPTracking(true)
+    lastXPValue = 0
+    lastXPUpdate = lastXPUpdate - 1
+    --InitializeXPTracking()
   elseif event == "PLAYER_LOGIN" then
     InitializeXPTracking()
   elseif event == "ADDON_LOADED" and select(1, ...) == "UltraHardcore" then
-    InitializeXPTracking()
+    -- This event is too soon to load player XP immediately but it is the only one called with a /reload
+    -- So use a timer to call InitializeXPTracking 
+    C_Timer.After(3.0, function() 
+      InitializeXPTracking()
+    end)
   end
 end)
 


### PR DESCRIPTION
### Summary

- Works around the wow client bug that causes XP loss when PLAYER_LEVEL_UP event fires
- Adds /uhcresettracking for beta users who have their verification status erroneously failed
- Properly recalculates XP for high level characters that install UHC after leveling (when all XP should be tracked as gained without addon)

My opinion is that the XP gained with/without functionality should receive additional testing before release.  **Especially for extreme ultra characters who have 0 for all of their xpGainedWithoutOption stats**

We will also want to remove the /uhcresettracking command once the feature exits beta testing.

### Screenshots / Video (optional)

View this message in the Discord dev chat
https://discord.com/channels/1343653057317048360/1436083977994895361/1438297682132340746

### Testing Steps (in-game)

How to test this fix for the reproducible bug [reported by @BoojiB](https://discord.com/channels/1343653057317048360/1436083977994895361/1438228463642345563).

1. Create a level 1 human rogue (for faster leveling to 2)
2. Kill wolves until you are level 2
3. Log out
4. Log back in
5. Expected result:
   - XP Gained with addon should be more than 400
   - XP Gained without addon should be 0

For higher level characters with existing XP drift and failed verification status
1. Run /uhcresettracking

