### PR TITLE
feat: add class color button to settings options

### DIFF
--- a/Settings/SettingsOptionsTab.lua
+++ b/Settings/SettingsOptionsTab.lua
@@ -1046,7 +1046,7 @@ function InitializeSettingsOptionsTab()
     row:SetPoint('TOPLEFT', colorSectionFrame, 'TOPLEFT', 20, -(COLOR_ROWS_TOP_OFFSET + ((rowIndex - 1) * ROW_HEIGHT)))
 
     local LABEL_WIDTH = 140
-    local SWATCH_WIDTH = 24
+    local SWATCH_WIDTH = 54
     local GAP = 12
 
     local label = row:CreateFontString(nil, 'OVERLAY', 'GameFontHighlight')
@@ -1104,6 +1104,19 @@ function InitializeSettingsOptionsTab()
     resetButton:SetPoint('LEFT', pickButton, 'RIGHT', 6, 0)
     resetButton:SetText('Reset')
 
+    local classButton = CreateFrame('Button', nil, row, 'UIPanelButtonTemplate')
+    classButton:SetSize(96, 20)
+    classButton:SetPoint('LEFT', resetButton, 'RIGHT', 6, 0)
+    classButton:SetText('Class Colour')
+    classButton:SetScript('OnClick', function()
+      local _, englishClass = UnitClass('player')
+      local classColor = RAID_CLASS_COLORS[englishClass]
+      if classColor then
+        tempSettings.resourceBarColors[powerKey] = { classColor.r, classColor.g, classColor.b }
+        setSwatchColor(classColor.r, classColor.g, classColor.b)
+      end
+    end)
+    
     pickButton:SetScript('OnClick', function()
       local r, g, b = getCurrentColor()
       local function onColorPicked()


### PR DESCRIPTION
### Summary

- Added a button to change the color of the bars to the class color and aligned it neater

### Screenshots / Video (optional)

<img width="648" height="291" alt="image" src="https://github.com/user-attachments/assets/9be6abc6-2e7d-4f42-8004-f564f9d83153" />


### Testing Steps (in-game)

How to enable/trigger the feature.

1. Test matrix:
   - Reload UI (/reload)
2. Expected result:
   - In Ultra UI Settings, you can pick the Class Colors now

