### PR TITLE
fix player arrow being re-added when minimap is turned off

### DIFF
--- a/Functions/HidePlayerMapIndicators.lua
+++ b/Functions/HidePlayerMapIndicators.lua
@@ -42,7 +42,9 @@ function RestorePlayerMapIndicators()
 
   -- Minimap: restore default player arrow texture
   if Minimap and Minimap.SetPlayerTexture then
-    Minimap:SetPlayerTexture('Interface\\Minimap\\MinimapArrow')
+    if not GLOBAL_SETTINGS or not GLOBAL_SETTINGS.hideMinimap then
+      Minimap:SetPlayerTexture('Interface\\Minimap\\MinimapArrow')
+    end
   end
 
   -- World Map: restore group/player pins behavior


### PR DESCRIPTION
### Summary

The route planning feature sometimes re-enabled the player arrow. This simply adds a check to ensure it doesn't do that when the minimap is supposed to be turned off.

### Screenshots / Video (optional)

This is the arrow issue that the PR fixes:

<img width="1512" height="982" alt="Screenshot 2025-11-14 at 9 08 02 AM" src="https://github.com/user-attachments/assets/d56d1173-2bb9-4356-8daf-6eac285431d4" />

