### PR TITLE
[Refactor] Move XP tracking changes into self contained script

### DIFF
--- a/Functions/AddonXPTracking.lua
+++ b/Functions/AddonXPTracking.lua
@@ -297,8 +297,8 @@ function AddonXPTracking:ValidateTotalStoredXP()
 end
 
 function AddonXPTracking:PrintXPVerificationWarning()
-    print(msgPrefix .. redTextColour .. "WARNING!|r Detected a " .. yellowTextColour ..  totalXP - storedTotalXP .. "|r XP difference!")
-    print(msgPrefix .. "Do not log out, /reload or change UHC settings until you gain XP again or you will gain unverified XP.")
+    print(msgPrefix .. redTextColour .. "WARNING!|r Detected " .. yellowTextColour ..  totalXP - storedTotalXP .. "|r missing XP!")
+    print(msgPrefix .. "Do not log out, /reload or change UHC settings until you gain XP again or it will be unverified.")
 end
 
 function AddonXPTracking:XPReport()

--- a/Functions/AddonXPTracking.lua
+++ b/Functions/AddonXPTracking.lua
@@ -1,0 +1,272 @@
+local statsInitialized = false
+
+local AddonXPTracking = {
+  TotalXPTable = {
+    [1]=400, [2]=900, [3]=1400, [4]=2100, [5]=2800, [6]=3600, [7]=4500, [8]=5400, [9]=6500, [10] = 7600,
+    [11] = 8800, [12] = 10100, [13] = 11400, [14] = 12900, [15] = 14400, [16] = 16000, [17] = 17700, [18] = 19400, [19] = 21300, [20] = 23200,
+    [21] = 25200, [22] = 27300, [23] = 29400, [24] = 31700, [25] = 34000, [26] = 36400, [27] = 38900, [28] = 41400, [29] = 44300, [30] = 47400,
+    [31] = 50800, [32] = 54500, [33] = 58600, [34] = 62800, [35] = 67100, [36] = 71600, [37] = 76100, [38] = 80800, [39] = 85700, [40] = 90700,
+    [41] = 95800, [42] = 101000, [43] = 106300, [44] = 111800, [45] = 117500, [46] = 123200, [47] = 129100, [48] = 135100, [49] = 141200, [50] = 147500,
+    [51] = 153900, [52] = 160400, [53] = 167100, [54] = 173900, [55] = 180800, [56] = 187900, [57] = 195000, [58] = 202300, [59] = 209800, [60] = 217400
+  },
+  highXpMark = 999999999,
+  DEBUGXP = true,
+  trackingInitialized = false
+}
+
+local yellowTextColour = '|cffffd000'
+local greenTextColour = '|cff33F24C'
+local redTextColour = '|cffFF4444'
+local msgPrefix = yellowTextColour .. "[|r" .. redTextColour .. "UHC|r" .. yellowTextColour .. "]|r "
+
+function AddonXPTracking:Stats()
+    return CharacterStats:GetCurrentCharacterStats() 
+end 
+
+function AddonXPTracking:UpdateStat(variable, value)
+    CharacterStats:UpdateStat(variable, value)
+end
+
+function AddonXPTracking:DefaultSettings()
+    return CharacterStats.defaults
+end
+
+function AddonXPTracking:XPTrackingDebug(msg)
+  if self.DEBUGXP ~= true then return end
+  print(msgPrefix .. "(" .. yellowTextColour .. "AddonXPTracking DEBUG|r:" .. greenTextColour .. GetTime() .. "|r) " .. msg)
+end 
+
+function AddonXPTracking:CalculateTotalXPGained()
+    local stats = self:Stats()
+    local currentLevel = UnitLevel("player")
+    local totalXP = 0
+
+    for i, xp in ipairs(self.TotalXPTable) do
+      if i < currentLevel then
+        totalXP = totalXP + xp
+      end
+    end
+    local currentXP = UnitXP('player')
+    totalXP = totalXP + currentXP
+    self:XPTrackingDebug("Total XP is " .. totalXP)
+    self:UpdateStat("xpTotal", totalXP)
+    if stats.xpGWA ~= nil and stats.xpGWA > 0 then
+      local xpGWOA = totalXP - stats.xpGWA
+      self:UpdateStat("xpGWOA", xpGWOA)
+      self:XPTrackingDebug("XP Gained without Addon is now " .. xpGWOA)
+    end
+    return totalXP
+end
+
+function AddonXPTracking:ShouldRecalculateXPGainedWithAddon()
+  local stats = self:Stats()
+  local playerLevel = UnitLevel("player")
+  if stats.xpGWA == nil and stats.xpGWOA == nil then
+    self:XPTrackingDebug("Recalculating because xpGWA and xpGWOA are both nil")
+    return true
+  elseif stats.xpGWA == 0 and stats.xpGWOA == 0 and stats.xpTotal > 0 then
+    self:XPTrackingDebug("Recalculating because xpGWA and xpGWOA are both 0, xpTotal is " .. stats.xpTotal)
+    return true
+  else
+    self:XPTrackingDebug("Addon XP should not be recalculated")
+    return false
+  end
+end
+
+function AddonXPTracking:GetHighestNonHealthStat()
+  local stats = self:Stats()
+  local highestXPStatName = ""
+  local highestXp = 0
+
+  for statName, _ in pairs(self:DefaultSettings()) do
+    local xpForStat = stats[statName] 
+    if statName ~= "xpTotal" and statName ~= "xpGWA" and statName ~= "xpGWOA" and statName ~= "playerJumps" then
+      local startIdx = string.find(statName, "lowestHealth")
+
+      if startIdx == nil then
+        if xpForStat == nil then xpForStat = 0 end
+        if xpForStat > highestXp then
+          highestXPStatName = statName
+          highestXp = xpForStat
+        end
+      end
+    end
+  end
+  self:XPTrackingDebug("Highest non-health XP stat is " .. highestXPStatName .. "=" .. highestXp)
+  return highestXp
+end
+
+
+function AddonXPTracking:GetHighestXpGainedStat()
+  local stats = self:Stats()
+  local highestXPStatName = ""
+  local highestXp = 0
+
+  for statName, _ in pairs(self:DefaultSettings()) do
+    local xpForStat = stats[statName] 
+    local startIdx = string.find(statName, "xpGainedWithoutOption")
+
+    if startIdx == 1 then
+      if xpForStat == nil then xpForStat = 0 end
+      if xpForStat > highestXp then
+        highestXPStatName = statName
+        highestXp = xpForStat
+      end
+    end
+  end
+  self:XPTrackingDebug("Highest XP stat is " .. highestXPStatName .. "=" ..highestXp)
+  return highestXp
+end
+
+function AddonXPTracking:GetLowestXpGainedStat() 
+  local stats = self:Stats()
+  local lowestXPStatName = ""
+  local lowestXP = self.highXpMark
+
+  for statName, _ in pairs(self:DefaultSettings()) do
+    local xpForStat = stats[statName] 
+
+    -- Only use XP Gained Without stats for finding lowest XP value
+    local startIdx = string.find(statName, "xpGainedWithoutOption")
+
+    if startIdx == 1 then
+      -- xpGainedWithoutOption stats that have never get incremented seem to be nil in the stats for some characters
+      if xpForStat == nil then xpForStat = 0 end
+      if xpForStat < lowestXP then
+        lowestXPStatName = statName
+        lowestXP = xpForStat
+      end
+    end
+  end
+  self:XPTrackingDebug("Lowest XP stat is " .. lowestXPStatName .. "=" .. lowestXP)
+  return lowestXP
+end
+
+-- This will retroactively figure out the amount of XP gained _with_ the addon
+function AddonXPTracking:ResetXPGainedWithAddon(forceReset)
+  local playerLevel = UnitLevel("player")
+  local xpDiff = 0
+  local xpWithoutAddon = 0
+  local totalXP = 0
+
+  if forceReset ~= nil or self:ShouldRecalculateXPGainedWithAddon() then
+    local lowestXP = self:GetLowestXpGainedStat() or nil
+    local highestXP = self:GetHighestXpGainedStat() or nil
+
+    if lowestXP < self.highXpMark then
+      totalXP = self:CalculateTotalXPGained()
+      local anyStat = self:GetHighestNonHealthStat()
+
+      if highestXP == 0 and anyStat == 0 and playerLevel > 1 then
+        self:XPTrackingDebug("All high stats are 0, player level is " .. playerLevel)
+        -- This player looks to have just turned ultra on so all their XP is without addon
+        xpDiff = 0
+      else
+        xpDiff = totalXP - lowestXP
+      end
+      xpWithoutAddon = totalXP - xpDiff
+
+      self:UpdateStat("xpGWA", xpDiff)
+      self:UpdateStat("xpGWOA", xpWithoutAddon)
+      self:UpdateStat("xpTotal", totalXP)
+    end
+  end
+end
+
+function AddonXPTracking:InitializeXpGainedWithAddon(lastXPValue)
+  local playerLevel = UnitLevel("player")
+  if lastXPValue == 0 and playerLevel > 1 then
+    -- This shouldn't happen but just in case, don't run until later
+    return false
+  end
+
+  local xp = self:CalculateTotalXPGained()
+  self:UpdateStat("xpTotal", xp)
+  self:XPTrackingDebug("Player XP total is " .. xp)
+
+  if playerLevel == 1 and lastXPValue == 0 then
+    self:UpdateStat("xpTotal", 0)
+    self:UpdateStat("xpGWA", 0)
+    self:UpdateStat("xpGWOA", 0)
+  elseif self:ShouldRecalculateXPGainedWithAddon() == true then
+    self:ResetXPGainedWithAddon(true)
+  end
+  return true
+end
+
+function AddonXPTracking:Initialize(lastXPValue)
+  if self.trackingInitialized ~= true then
+    self:InitializeXpGainedWithAddon(lastXPValue)
+    self.trackingInitialized = true
+  end
+end
+
+function AddonXPTracking:ShouldStoreStat(xpVariable)
+  return xpVariable == "xpGWOA"
+end
+
+function AddonXPTracking:ShouldTrackStat(xpVariable)
+  if xpVariable == "xpGWA" or xpVariable == "xpTotal" then
+    return true
+  else
+    return false
+  end
+end
+
+function AddonXPTracking:WithAddon()
+  return self:Stats().xpGWA
+end
+
+function AddonXPTracking:WithoutAddon()
+  return self:Stats().xpGWOA
+end
+
+function AddonXPTracking:XPIsVerified()
+  local stats = self:Stats()
+  local isVerified = stats.xpGWA == stats.xpTotal and stats.xpGWOA == 0
+  self:XPTrackingDebug("Addon XP verification status: " .. tostring(isVerified))
+  return isVerified
+end
+
+function AddonXPTracking:XPForLevel(level)
+  return self.TotalXPTable[level]
+end
+
+function AddonXPTracking:GetXP(levelUp) 
+  if levelUp then
+    local newLevel = UnitLevel("player")
+    return AddonXPTracking:XPForLevel(newLevel)
+  else
+    return UnitXP("player")
+  end
+end
+
+function AddonXPTracking:NewLastXPValue(levelUp, currentXp)
+  if levelUp then
+    return 0
+  else
+    return currentXp
+  end
+end
+
+-- We do not want a reset command for this in a release
+SLASH_DEVRESETXP1 = '/uhcresettracking'
+SlashCmdList['DEVRESETXP'] = function()
+  AddonXPTracking:UpdateStat("xpTotal", nil)
+  AddonXPTracking:UpdateStat("xpGWA", nil)
+  AddonXPTracking:UpdateStat("xpGWOA", nil)
+  AddonXPTracking:ResetXPGainedWithAddon(true)
+  print(msgPrefix .. yellowTextColour ..  "ADDON XP RESET.|r Please do " .. redTextColour .. "/reload|r now")
+end
+
+SLASH_XPGWAREPORT1 = '/uhcxpreport'
+SlashCmdList['XPGWAREPORT'] = function() 
+  local stats = AddonXPTracking:Stats()
+  local verified = AddonXPTracking:XPIsVerified() and greenTextColour .. "is fully verified|r" or redTextColour .. "is not fully verified|r"
+  print(msgPrefix .. yellowTextColour .. "Total XP: |r" .. tostring(stats.xpTotal))
+  print(msgPrefix .. yellowTextColour .. "XP Gained With Addon: " .. greenTextColour .. tostring(stats.xpGWA) .. "|r")
+  print(msgPrefix .. yellowTextColour .. "XP Gained Without Addon: |r".. redTextColour .. tostring(stats.xpGWOA) .. "|r")
+  print(msgPrefix .. yellowTextColour .. "Your addon XP |r" .. verified)
+end
+
+_G.AddonXPTracking = AddonXPTracking

--- a/Functions/AddonXPTracking.lua
+++ b/Functions/AddonXPTracking.lua
@@ -344,10 +344,13 @@ function AddonXPTracking:XPReport()
   if AddonXPTracking:ValidateTotalStoredXP() ~= true then
     AddonXPTracking:PrintXPVerificationWarning()
   end
+
+  -- REMOVE BEFORE RELEASE
+  print(msgPrefix .. "If your XP was invalidated from the Nov 12th beta, run " .. redTextColour .. "/uhcresettracking|r to correct this")
 end 
 
 
--- We do not want a reset command for this in a release
+-- REMOVE BEFORE RELEASE
 SLASH_DEVRESETXP1 = '/uhcresettracking'
 SlashCmdList['DEVRESETXP'] = function()
   AddonXPTracking:UpdateStat("xpTotal", nil)

--- a/Functions/AddonXPTracking.lua
+++ b/Functions/AddonXPTracking.lua
@@ -10,7 +10,7 @@ local AddonXPTracking = {
     [51] = 153900, [52] = 160400, [53] = 167100, [54] = 173900, [55] = 180800, [56] = 187900, [57] = 195000, [58] = 202300, [59] = 209800, [60] = 217400
   },
   highXpMark = 999999999,
-  DEBUGXP = true,
+  DEBUGXP = false,
   trackingInitialized = false
 }
 

--- a/Functions/AddonXPTracking.lua
+++ b/Functions/AddonXPTracking.lua
@@ -235,7 +235,9 @@ end
 function AddonXPTracking:GetXP(levelUp) 
   if levelUp then
     local newLevel = UnitLevel("player")
-    return AddonXPTracking:XPForLevel(newLevel)
+    local levelXP = AddonXPTracking:XPForLevel(newLevel)
+    self:XPTrackingDebug("Leveling up, reporting XP as" .. levelXP)
+    return levelXP
   else
     return UnitXP("player")
   end
@@ -243,11 +245,22 @@ end
 
 function AddonXPTracking:NewLastXPValue(levelUp, currentXp)
   if levelUp then
+    self:XPTrackingDebug("New XP value is 0 due to level up")
     return 0
   else
     return currentXp
   end
 end
+
+function AddonXPTracking:NewLastXPUpdate(levelUp, currentTime) 
+  if levelUp then
+    self:XPTrackingDebug("Falsifying last update timestamp to ensure extra level up XP is counted")
+    return (currentTime - 1)
+  else
+    return currentTime
+  end
+end
+
 
 -- We do not want a reset command for this in a release
 SLASH_DEVRESETXP1 = '/uhcresettracking'

--- a/Functions/AddonXPTracking.lua
+++ b/Functions/AddonXPTracking.lua
@@ -150,7 +150,7 @@ function AddonXPTracking:ResetXPGainedWithAddon(forceReset)
   local xpWithoutAddon = 0
   local totalXP = 0
 
-  if forceReset ~= nil or self:ShouldRecalculateXPGainedWithAddon() then
+--  if forceReset ~= nil or self:ShouldRecalculateXPGainedWithAddon() then
     local lowestXP = self:GetLowestXpGainedStat() or nil
     local highestXP = self:GetHighestXpGainedStat() or nil
 
@@ -171,7 +171,7 @@ function AddonXPTracking:ResetXPGainedWithAddon(forceReset)
       self:UpdateStat("xpGWOA", xpWithoutAddon)
       self:UpdateStat("xpTotal", totalXP)
     end
-  end
+  -- end
 end
 
 function AddonXPTracking:InitializeXpGainedWithAddon(lastXPValue)
@@ -189,7 +189,9 @@ function AddonXPTracking:InitializeXpGainedWithAddon(lastXPValue)
     self:UpdateStat("xpTotal", 0)
     self:UpdateStat("xpGWA", 0)
     self:UpdateStat("xpGWOA", 0)
-  elseif self:ShouldRecalculateXPGainedWithAddon() == true then
+  --[[elseif self:ShouldRecalculateXPGainedWithAddon() == true then
+    self:ResetXPGainedWithAddon(true)]]
+  else 
     self:ResetXPGainedWithAddon(true)
   end
   return true

--- a/Functions/AddonXPTracking.lua
+++ b/Functions/AddonXPTracking.lua
@@ -37,6 +37,7 @@ function AddonXPTracking:XPTrackingDebug(msg)
 end 
 
 function AddonXPTracking:CalculateTotalXPGained()
+    self:XPTrackingDebug("Calculating Total XP for " .. redTextColour .. UnitGUID("player") .. "|r")
     local stats = self:Stats()
     local currentLevel = UnitLevel("player")
     local totalXP = 0
@@ -233,19 +234,24 @@ function AddonXPTracking:XPForLevel(level)
 end
 
 function AddonXPTracking:GetXP(levelUp) 
+  if levelUp == nil then levelUp = false end
+
   if levelUp then
     local newLevel = UnitLevel("player")
     local levelXP = AddonXPTracking:XPForLevel(newLevel)
-    self:XPTrackingDebug("Leveling up, reporting XP as" .. levelXP)
+    self:XPTrackingDebug("Leveling up, reporting XP as " .. levelXP)
     return levelXP
   else
+    self:XPTrackingDebug("GetXP=" .. UnitXP("player"))
     return UnitXP("player")
   end
 end
 
 function AddonXPTracking:NewLastXPValue(levelUp, currentXp)
+  if levelUp == nil then levelUp = false end
+
   if levelUp then
-    self:XPTrackingDebug("New XP value is 0 due to level up")
+    self:XPTrackingDebug("New XP value is 0 due to level up.  XP was " .. currentXp)
     return 0
   else
     return currentXp
@@ -253,9 +259,12 @@ function AddonXPTracking:NewLastXPValue(levelUp, currentXp)
 end
 
 function AddonXPTracking:NewLastXPUpdate(levelUp, currentTime) 
+  if levelUp == nil then levelUp = false end
+
   if levelUp then
-    self:XPTrackingDebug("Falsifying last update timestamp to ensure extra level up XP is counted")
-    return (currentTime - 1)
+    local newTime = currentTime - 1
+    self:XPTrackingDebug("Falsifying last update timestamp from " .. currentTime .. " to " .. newTime)
+    return newTime
   else
     return currentTime
   end

--- a/Functions/AddonXPTracking.lua
+++ b/Functions/AddonXPTracking.lua
@@ -214,6 +214,10 @@ function AddonXPTracking:ShouldTrackStat(xpVariable)
   end
 end
 
+function AddonXPTracking:TotalXP()
+  return self:Stats().xpTotal
+end
+
 function AddonXPTracking:WithAddon()
   return self:Stats().xpGWA
 end
@@ -283,11 +287,10 @@ end
 
 SLASH_XPGWAREPORT1 = '/uhcxpreport'
 SlashCmdList['XPGWAREPORT'] = function() 
-  local stats = AddonXPTracking:Stats()
   local verified = AddonXPTracking:XPIsVerified() and greenTextColour .. "is fully verified|r" or redTextColour .. "is not fully verified|r"
-  print(msgPrefix .. yellowTextColour .. "Total XP: |r" .. tostring(stats.xpTotal))
-  print(msgPrefix .. yellowTextColour .. "XP Gained With Addon: " .. greenTextColour .. tostring(stats.xpGWA) .. "|r")
-  print(msgPrefix .. yellowTextColour .. "XP Gained Without Addon: |r".. redTextColour .. tostring(stats.xpGWOA) .. "|r")
+  print(msgPrefix .. yellowTextColour .. "Total XP: |r" .. tostring(AddonXPTracking:TotalXP()))
+  print(msgPrefix .. yellowTextColour .. "XP Gained With Addon: " .. greenTextColour .. tostring(AddonXPTracking:WithAddon()) .. "|r")
+  print(msgPrefix .. yellowTextColour .. "XP Gained Without Addon: |r".. redTextColour .. tostring(AddonXPTracking:WithoutAddon()) .. "|r")
   print(msgPrefix .. yellowTextColour .. "Your addon XP |r" .. verified)
 end
 

--- a/Functions/AddonXPTracking.lua
+++ b/Functions/AddonXPTracking.lua
@@ -202,11 +202,11 @@ function AddonXPTracking:Initialize(lastXPValue)
 end
 
 function AddonXPTracking:ShouldStoreStat(xpVariable)
-  return xpVariable == "xpGWOA"
+  return xpVariable ~= "xpGWOA"
 end
 
 function AddonXPTracking:ShouldTrackStat(xpVariable)
-  if xpVariable == "xpGWA" or xpVariable == "xpTotal" then
+  if xpVariable == "xpGWA" or xpVariable == "xpTotal" or xpVariable == "xpGWOA" then
     return true
   else
     return false

--- a/Functions/DB/CharacterStats.lua
+++ b/Functions/DB/CharacterStats.lua
@@ -1,15 +1,4 @@
 -- 🟢 Character Stats Management
-local statsInitialized = false
-
-local TotalXPTable = {
-  [1]=400, [2]=900, [3]=1400, [4]=2100, [5]=2800, [6]=3600, [7]=4500, [8]=5400, [9]=6500, [10] = 7600,
-  [11] = 8800, [12] = 10100, [13] = 11400, [14] = 12900, [15] = 14400, [16] = 16000, [17] = 17700, [18] = 19400, [19] = 21300, [20] = 23200,
-  [21] = 25200, [22] = 27300, [23] = 29400, [24] = 31700, [25] = 34000, [26] = 36400, [27] = 38900, [28] = 41400, [29] = 44300, [30] = 47400,
-  [31] = 50800, [32] = 54500, [33] = 58600, [34] = 62800, [35] = 67100, [36] = 71600, [37] = 76100, [38] = 80800, [39] = 85700, [40] = 90700,
-  [41] = 95800, [42] = 101000, [43] = 106300, [44] = 111800, [45] = 117500, [46] = 123200, [47] = 129100, [48] = 135100, [49] = 141200, [50] = 147500,
-  [51] = 153900, [52] = 160400, [53] = 167100, [54] = 173900, [55] = 180800, [56] = 187900, [57] = 195000, [58] = 202300, [59] = 209800, [60] = 217400
-}
-
 local CharacterStats = {
   -- Default values for new characters
   defaults = {
@@ -219,145 +208,9 @@ function CharacterStats:ResetWorldBossesSlain()
   SaveDBData('characterStats', UltraHardcoreDB.characterStats)
 end
 
+-- Deprecated: This function will be removed on a future release
 function CharacterStats:ReportXPWithoutAddon()
-  local stats = CharacterStats:GetCurrentCharacterStats()
-  local xpGainedWithoutAddon = stats.xpGWOA
-  if xpGainedWithoutAddon ~= nil then
-    return xpGainedWithoutAddon
-  else
-    print('Cannot load XP Gained without addon stat')
-    return false
-  end
-end
-
-function CharacterStats:CalculateTotalXPGained()
-    local stats = CharacterStats:GetCurrentCharacterStats()
-    local currentLevel = UnitLevel("player")
-    local totalXP = 0
-
-    for i, xp in ipairs(TotalXPTable) do
-      if i < currentLevel then
-        totalXP = totalXP + xp
-      end
-    end
-    local currentXP = UnitXP('player')
-    totalXP = totalXP + currentXP
-    CharacterStats:UpdateStat("xpTotal", totalXP)
-    if stats.xpGWA ~= nil and stats.xpGWA > 0 then
-      CharacterStats:UpdateStat("xpGWOA", totalXP - stats.xpGWA)
-    end
-    return totalXP
-end
-
-function CharacterStats:ShouldRecalculateXPGainedWithAddon(stats)
-  local playerLevel = UnitLevel("player")
-  if stats.xpGWA == nil and stats.xpGWOA == nil then
-    return true
-  elseif stats.xpGWA == 0 and stats.xpGWOA == 0 and stats.xpTotal > 0 then
-    return true
-  else
-    return false
-  end
-end
-
-function CharacterStats:GetHighestNonHealthStat(stats)
-  local highestXp = 0
-  for statName, _ in pairs(self.defaults) do
-    local xpForStat = stats[statName] 
-    if statName ~= "xpTotal" and statName ~= "xpGWA" and statName ~= "xpGWOA" and statName ~= "playerJumps" then
-      local startIdx = string.find(statName, "lowestHealth")
-
-      if startIdx == nil then
-        if xpForStat == nil then xpForStat = 0 end
-        if xpForStat > highestXp then
-          highestXp = xpForStat
-        end
-      end
-    end
-  end
-  return highestXp
-end
-
-
-function CharacterStats:GetHighestXpGainedStat(stats)
-  local highestXp = 0
-  for statName, _ in pairs(self.defaults) do
-    local xpForStat = stats[statName] 
-    local startIdx = string.find(statName, "xpGainedWithoutOption")
-
-    if startIdx == 1 then
-      if xpForStat == nil then xpForStat = 0 end
-      if xpForStat > highestXp then
-        highestXp = xpForStat
-      end
-    end
-  end
-  return highestXp
-end
-
-function CharacterStats:GetLowestXpGainedStat(stats) 
-  local lowestXP = 999999999
-  for statName, _ in pairs(self.defaults) do
-    local xpForStat = stats[statName] 
-
-    -- Only use XP Gained Without stats for finding lowest XP value
-    local startIdx = string.find(statName, "xpGainedWithoutOption")
-
-    if startIdx == 1 then
-      -- xpGainedWithoutOption stats that have never get incremented seem to be nil in the stats for some characters
-      if xpForStat == nil then xpForStat = 0 end
-      if xpForStat < lowestXP then
-        lowestXP = xpForStat
-      end
-    end
-  end
-  return lowestXP
-end
-
--- This will retroactively figure out the amount of XP gained _with_ the addon
-function CharacterStats:ResetXPGainedWithAddon(playerLevel, forceReset)
-  local stats = self:GetCurrentCharacterStats()
-  local xpDiff = 0
-  local xpWithoutAddon = 0
-  local totalXP = 0
-
-  if forceReset ~= nil or self:ShouldRecalculateXPGainedWithAddon(stats) then
-    local lowestXP = self:GetLowestXpGainedStat(stats) or nil
-    local highestXP = self:GetHighestXpGainedStat(stats) or nil
-
-    if lowestXP < 99999999 then
-      totalXP = self.CalculateTotalXPGained()
-      local anyStat = self:GetHighestNonHealthStat(stats)
-
-      if highestXP == 0 and anyStat == 0 and playerLevel > 1 then
-        -- This player looks to have just turned ultra on so all their XP is without addon
-        xpDiff = 0
-      else
-        xpDiff = totalXP - lowestXP
-      end
-      xpWithoutAddon = totalXP - xpDiff
-
-      CharacterStats:UpdateStat("xpGWA", xpDiff)
-      CharacterStats:UpdateStat("xpGWOA", xpWithoutAddon)
-      CharacterStats:UpdateStat("xpTotal", totalXP)
-    end
-  end
-end
-
-function CharacterStats:XPChecksum(playerXP, deficit, playerLevel)
-  local stats = self:GetCurrentCharacterStats()
-
-  if playerXP == nil then playerXP = stats.xpTotal end
-  if deficit == nil then deficit = stats.xpGWOA end
-  if playerLevel == nil then playerLevel = UnitLevel("player") end
-
-  local digits = getDigitsFromString(playerXP - deficit)
-  local checkTotal = 0 
-  for i, digit in ipairs(digits) do
-    checkTotal = checkTotal + (i * digit)
-  end
-
-  return string.format("%.2f", (checkTotal / playerLevel))
+  return AddonXPTracking:WithoutAddon()
 end
 
 -- Get the current character's stats
@@ -736,9 +589,6 @@ end
 -- Export the CharacterStats object
 _G.CharacterStats = CharacterStats
 
--- Export TotalXPTable so TrackXPPerSetting can use it during level ups
-_G.TotalXPTable = TotalXPTable
-
 -- Register slash commands for individual stat resets
 SLASH_RESETLOWESTHEALTH1 = '/resetlowesthealth'
 SlashCmdList['RESETLOWESTHEALTH'] = function()
@@ -841,48 +691,6 @@ SlashCmdList['SETLOWESTHEALTH'] = function(msg)
   CharacterStats:SetLowestHealth(msg)
 end
 
--- We do not want a reset command for this in a release
-SLASH_DEVRESETXP1 = '/uhcresettracking'
-SlashCmdList['DEVRESETXP'] = function()
-  CharacterStats:UpdateStat("xpTotal", nil)
-  CharacterStats:UpdateStat("xpGWA", nil)
-  CharacterStats:UpdateStat("xpGWOA", nil)
-  CharacterStats:ResetXPGainedWithAddon(true)
-end
-
-SLASH_XPGWAREPORT1 = '/uhcxpreport'
-SlashCmdList['XPGWAREPORT'] = function() 
-  local stats = CharacterStats:GetCurrentCharacterStats()
-  print("Total XP: " .. tostring(stats.xpTotal))
-  print("XP Gained With Addon: " .. tostring(stats.xpGWA))
-  print("XP Gained Without Addon: " .. tostring(stats.xpGWOA))
-end
-
-SLASH_CHECKXPREPORT1 = '/uhccheckxp'
-SlashCmdList['CHECKXPREPORT'] = function(msg)
-  local playerXP = 0
-  local deficit = 0
-  local level = 0
-  if msg == nil or msg == '' then 
-    print('Check for a valid /uhcv message.  If the checksum from this command does not match theirs, it might be fake.')
-    print('Usage: /uhccheckxp total_xp xp_without_uhc player_level')
-  else
-    local results = {}
-    for part in string.gmatch(msg, "([^ ]+)") do
-        table.insert(results, part)
-    end
-    playerXP = results[1]
-    deficit = results[2]
-    level = results[3]
-
-    if playerXP ~= nil and deficit ~= nil and level ~= nil then
-      local checksum = CharacterStats:XPChecksum(playerXP, deficit, level)
-      print('Player checksum should be ' .. checksum)
-    else
-      print('Cannot check XP report, run /uhcxp by itself to see usage')
-    end
-  end
-end
 -- Slash command to post version to current chat
 SLASH_POSTVERSION1 = '/uhcversion'
 SLASH_POSTVERSION2 = '/uhcv'
@@ -891,16 +699,6 @@ SlashCmdList['POSTVERSION'] = function()
   local playerName = UnitName('player')
   local message = playerName .. ' is using UltraHardcore version ' .. version
 
-  local xpDeficit = CharacterStats:ReportXPWithoutAddon()
-
-  if xpDeficit ~= false then
-    local stats = CharacterStats:GetCurrentCharacterStats()
-    local playerXP = stats.xpTotal
-    message = message
-              .. ' [Total XP: ' .. formatNumberWithCommas(playerXP) .. ']' 
-              .. ' [XP w/o UHC: ' .. formatNumberWithCommas(xpDeficit) .. ']'
-              .. ' (Checksum: '.. CharacterStats:XPChecksum() .. ')'
-  end
   -- Determine the best chat channel to use
   local chatType = nil
   local chatTarget = nil

--- a/Functions/DB/CharacterStats.lua
+++ b/Functions/DB/CharacterStats.lua
@@ -1,3 +1,5 @@
+local statsInitialized = false
+
 -- 🟢 Character Stats Management
 local CharacterStats = {
   -- Default values for new characters

--- a/Functions/Overlays/MainScreenStatistics.lua
+++ b/Functions/Overlays/MainScreenStatistics.lua
@@ -309,7 +309,7 @@ blockedMapOpensValue:SetFont('Fonts\\FRIZQT__.TTF', 14)
 -- XP Gained With Addon
 local xpGWALabel = statsFrame:CreateFontString(nil, 'OVERLAY', 'GameFontHighlight')
 xpGWALabel:SetPoint('TOPLEFT', statsFrame, 'TOPLEFT', 10, -245)
-xpGWALabel:SetText('XP w Addon:')
+xpGWALabel:SetText('Verified XP:')
 xpGWALabel:SetFont('Fonts\\FRIZQT__.TTF', 14)
 
 local xpGWAValue = statsFrame:CreateFontString(nil, 'OVERLAY', 'GameFontHighlight')
@@ -321,7 +321,7 @@ xpGWAValue:SetFont('Fonts\\FRIZQT__.TTF', 14)
 -- XP Gained Without Addon
 local xpGWOALabel = statsFrame:CreateFontString(nil, 'OVERLAY', 'GameFontHighlight')
 xpGWOALabel:SetPoint('TOPLEFT', statsFrame, 'TOPLEFT', 10, -245)
-xpGWOALabel:SetText('XP w/o Addon:')
+xpGWOALabel:SetText('Unverified XP:')
 xpGWOALabel:SetFont('Fonts\\FRIZQT__.TTF', 14)
 
 local xpGWOAValue = statsFrame:CreateFontString(nil, 'OVERLAY', 'GameFontHighlight')

--- a/Functions/Statistics/TrackXPPerSetting.lua
+++ b/Functions/Statistics/TrackXPPerSetting.lua
@@ -71,7 +71,6 @@ local function UpdateXPTracking(levelUp)
        
       -- For boolean settings, if they're false, we're gaining XP "without" that option
       if not isSettingEnabled or AddonXPTracking:ShouldTrackStat(xpVariable) then
-        AddonXPTracking:XPTrackingDebug(xpVariable)
         if AddonXPTracking:ShouldStoreStat(xpVariable) then 
           local currentXPForSetting = CharacterStats:GetStat(xpVariable) or 0
           local newXPForSetting = currentXPForSetting + xpGained

--- a/Functions/Statistics/TrackXPPerSetting.lua
+++ b/Functions/Statistics/TrackXPPerSetting.lua
@@ -9,6 +9,7 @@ local settingToXPVariable = {
   -- Total XP, not tied to settings
   xpGWA = 'xpGWA',
   xpGWOA = 'xpGWOA',
+  xpTotal = 'xpTotal', -- DO NOT REMOVE THIS IT IS IMPORTANT FOR XP TRACKING!
   -- Lite Preset Settings
   hidePlayerFrame = 'xpGainedWithoutOptionHidePlayerFrame',
   showOnScreenStatistics = 'xpGainedWithoutOptionShowOnScreenStatistics',
@@ -61,14 +62,16 @@ local function UpdateXPTracking(levelUp)
   -- Only update if XP has increased and enough time has passed (prevent spam)
   if currentXP > lastXPValue and (currentTime - lastXPUpdate) > 1 then
     local xpGained = currentXP - lastXPValue
+    AddonXPTracking:XPTrackingDebug("UpdateXPTracking conditional passed XP gained = " .. xpGained)
     
     -- Update XP tracking for each setting that is currently disabled
     for settingName, xpVariable in pairs(settingToXPVariable) do
       -- Check if this setting is currently disabled (meaning we're gaining XP "without" it)
       local isSettingEnabled = GLOBAL_SETTINGS[settingName]
-      
+       
       -- For boolean settings, if they're false, we're gaining XP "without" that option
       if not isSettingEnabled or AddonXPTracking:ShouldTrackStat(xpVariable) then
+        AddonXPTracking:XPTrackingDebug(xpVariable)
         if AddonXPTracking:ShouldStoreStat(xpVariable) then 
           local currentXPForSetting = CharacterStats:GetStat(xpVariable) or 0
           local newXPForSetting = currentXPForSetting + xpGained
@@ -80,6 +83,7 @@ local function UpdateXPTracking(levelUp)
     lastXPValue = AddonXPTracking:NewLastXPValue(levelUp, currentXP)
     lastXPUpdate = AddonXPTracking:NewLastXPUpdate(levelUp, currentTime)
   end
+
 end
 
 -- Function to get XP gained for a specific setting
@@ -106,8 +110,10 @@ xpTrackingFrame:RegisterEvent("ADDON_LOADED")
 
 xpTrackingFrame:SetScript("OnEvent", function(self, event, ...)
   if event == "PLAYER_XP_UPDATE" then
+    AddonXPTracking:XPTrackingDebug("PLAYER_XP_UPDATE event fired")
     UpdateXPTracking(false)
   elseif event == "PLAYER_LEVEL_UP" then
+    AddonXPTracking:XPTrackingDebug("PLAYER_LEVEL_UP event fired")
     UpdateXPTracking(true)
   elseif event == "PLAYER_LOGIN" then
     InitializeXPTracking()

--- a/Functions/Statistics/TrackXPPerSetting.lua
+++ b/Functions/Statistics/TrackXPPerSetting.lua
@@ -78,7 +78,7 @@ local function UpdateXPTracking(levelUp)
     end
     
     lastXPValue = AddonXPTracking:NewLastXPValue(levelUp, currentXP)
-    lastXPUpdate = currentTime
+    lastXPUpdate = AddonXPTracking:NewLastXPUpdate(levelUp, currentTime)
   end
 end
 

--- a/Functions/Statistics/TrackXPPerSetting.lua
+++ b/Functions/Statistics/TrackXPPerSetting.lua
@@ -69,9 +69,11 @@ local function UpdateXPTracking(levelUp)
       
       -- For boolean settings, if they're false, we're gaining XP "without" that option
       if not isSettingEnabled or AddonXPTracking:ShouldTrackStat(xpVariable) then
-        local currentXPForSetting = CharacterStats:GetStat(xpVariable) or 0
-        local newXPForSetting = currentXPForSetting + xpGained
-        CharacterStats:UpdateStat(xpVariable, newXPForSetting)
+        if AddonXPTracking:ShouldStoreStat(xpVariable) then 
+          local currentXPForSetting = CharacterStats:GetStat(xpVariable) or 0
+          local newXPForSetting = currentXPForSetting + xpGained
+          CharacterStats:UpdateStat(xpVariable, newXPForSetting)
+        end
       end
     end
     

--- a/Functions/Statistics/TrackXPPerSetting.lua
+++ b/Functions/Statistics/TrackXPPerSetting.lua
@@ -41,27 +41,6 @@ local settingToXPVariable = {
 local sessionStartXP = nil
 local lastXPUpdate = nil
 local lastXPValue = nil
-local xpTrackingInitialized = false
-
-local function InitializeXpGainedWithAddon(playerLevel, lastXPValue, stats)
-  if lastXPValue == 0 and playerLevel > 1 then
-    -- This shouldn't happen but just in case, don't run until later
-    return false
-  end
-
-  CharacterStats:UpdateStat("xpTotal", CharacterStats:CalculateTotalXPGained())
-
-  local shouldRecalculate = CharacterStats:ShouldRecalculateXPGainedWithAddon(stats)
-
-  if playerLevel == 1 and lastXPValue == 0 then
-    CharacterStats:UpdateStat("xpTotal", 0)
-    CharacterStats:UpdateStat("xpGWA", 0)
-    CharacterStats:UpdateStat("xpGWOA", 0)
-  elseif shouldRecalculate  == true then
-    CharacterStats:ResetXPGainedWithAddon(playerLevel, true)
-  end
-  return true
-end
 
 -- Function to initialize XP tracking
 local function InitializeXPTracking()
@@ -69,31 +48,15 @@ local function InitializeXPTracking()
   -- Start tracking from current XP for this session
   lastXPValue = UnitXP("player")
   lastXPUpdate = GetTime()
-
-  -- This code only needs to run once either on login or reload
-  if xpTrackingInitialized ~= true then
-    local stats = CharacterStats:GetCurrentCharacterStats()
-    InitializeXpGainedWithAddon(playerLevel, lastXPValue, stats)
-    xpTrackingInitialized = true
-  end
+  AddonXPTracking:Initialize(lastXPValue)
 end
 
 -- Function to update XP tracking for each setting
 local function UpdateXPTracking(levelUp)
   if levelUp == nil then levelUp = false end
 
-  local currentXP = 0
+  local currentXP = AddonXPTracking:GetXP(levelUp)
   local currentTime = GetTime()
-
-  if levelUp then
-    -- The game does not report the correct XP amount on level up, so we calculate it
-    local newLevel = UnitLevel("player")
-    local xpThisLevel = TotalXPTable[newLevel]
-    currentXP = xpThisLevel
-  else
-    currentXP = UnitXP("player")
-  end
-
   
   -- Only update if XP has increased and enough time has passed (prevent spam)
   if currentXP > lastXPValue and (currentTime - lastXPUpdate) > 1 then
@@ -105,27 +68,15 @@ local function UpdateXPTracking(levelUp)
       local isSettingEnabled = GLOBAL_SETTINGS[settingName]
       
       -- For boolean settings, if they're false, we're gaining XP "without" that option
-      if not isSettingEnabled or xpVariable == "xpGWA" or xpVariable == "xpGWOA" or xpVariable == "xpTotal" then
-        -- We do not want to track xpGWOA while the addon is running even though the setting is always false
-        if xpVariable ~= "xpGWOA" then 
-          local currentXPForSetting = CharacterStats:GetStat(xpVariable) or 0
-          local newXPForSetting = currentXPForSetting + xpGained
-          CharacterStats:UpdateStat(xpVariable, newXPForSetting)
-        end
+      if not isSettingEnabled or AddonXPTracking:ShouldTrackStat(xpVariable) then
+        local currentXPForSetting = CharacterStats:GetStat(xpVariable) or 0
+        local newXPForSetting = currentXPForSetting + xpGained
+        CharacterStats:UpdateStat(xpVariable, newXPForSetting)
       end
     end
     
-    if levelUp then
-      -- We just leveled up so our UnitXP is going to be only the amount in excess of the level up threshhold
-      -- Leveling up means our UnitXP is effectively 0, so set that value
-      --
-      -- Do not reset the time because UpdateXPTracking is going to fire again immediately
-      -- after PLAYER_LEVEL_UP and we want to count that XP
-      lastXPValue = 0
-    else
-      lastXPValue = currentXP
-      lastXPUpdate = currentTime
-    end
+    lastXPValue = AddonXPTracking:NewLastXPValue(levelUp, currentXP)
+    lastXPUpdate = currentTime
   end
 end
 
@@ -155,11 +106,7 @@ xpTrackingFrame:SetScript("OnEvent", function(self, event, ...)
   if event == "PLAYER_XP_UPDATE" then
     UpdateXPTracking(false)
   elseif event == "PLAYER_LEVEL_UP" then
-    -- Reset tracking when leveling up
     UpdateXPTracking(true)
-    lastXPValue = 0
-    lastXPUpdate = lastXPUpdate - 1
-    --InitializeXPTracking()
   elseif event == "PLAYER_LOGIN" then
     InitializeXPTracking()
   elseif event == "ADDON_LOADED" and select(1, ...) == "UltraHardcore" then

--- a/Functions/Statistics/TrackXPPerSetting.lua
+++ b/Functions/Statistics/TrackXPPerSetting.lua
@@ -103,12 +103,18 @@ _G.GetXPGainedForSetting = GetXPGainedForSetting
 -- Register events for XP tracking
 local xpTrackingFrame = CreateFrame("Frame")
 xpTrackingFrame:RegisterEvent("PLAYER_XP_UPDATE")
+xpTrackingFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
 xpTrackingFrame:RegisterEvent("PLAYER_LEVEL_UP")
 xpTrackingFrame:RegisterEvent("PLAYER_LOGIN")
 xpTrackingFrame:RegisterEvent("ADDON_LOADED")
 
 xpTrackingFrame:SetScript("OnEvent", function(self, event, ...)
-  if event == "PLAYER_XP_UPDATE" then
+  if event == "PLAYER_REGEN_ENABLED" then
+    AddonXPTracking:XPTrackingDebug("PLAYER_REGEN_ENABLED event fired")
+    C_Timer.After(2.0, function() 
+      UpdateXPTracking(false)
+    end)
+  elseif event == "PLAYER_XP_UPDATE" then
     AddonXPTracking:XPTrackingDebug("PLAYER_XP_UPDATE event fired")
     UpdateXPTracking(false)
   elseif event == "PLAYER_LEVEL_UP" then
@@ -116,6 +122,7 @@ xpTrackingFrame:SetScript("OnEvent", function(self, event, ...)
     UpdateXPTracking(true)
   elseif event == "PLAYER_LOGIN" then
     InitializeXPTracking()
+    AddonXPTracking:XPReport()
   elseif event == "ADDON_LOADED" and select(1, ...) == "UltraHardcore" then
     -- This event is too soon to load player XP immediately but it is the only one called with a /reload
     -- So use a timer to call InitializeXPTracking 

--- a/Functions/Statistics/TrackXPPerSetting.lua
+++ b/Functions/Statistics/TrackXPPerSetting.lua
@@ -58,11 +58,11 @@ local function UpdateXPTracking(levelUp)
 
   local currentXP = AddonXPTracking:GetXP(levelUp)
   local currentTime = GetTime()
-  
+  AddonXPTracking:XPTrackingDebug("XP Check " .. lastXPValue .. " vs " .. currentXP)
   -- Only update if XP has increased and enough time has passed (prevent spam)
   if currentXP > lastXPValue and (currentTime - lastXPUpdate) > 1 then
     local xpGained = currentXP - lastXPValue
-    AddonXPTracking:XPTrackingDebug("UpdateXPTracking conditional passed XP gained = " .. xpGained)
+    AddonXPTracking:XPTrackingDebug("UpdateXPTracking conditional passed. XP gained = " .. xpGained)
     local statsChanged = 0 
     local stats = CharacterStats:GetCurrentCharacterStats()
 
@@ -81,7 +81,7 @@ local function UpdateXPTracking(levelUp)
           ]]
 
           -- Access character stats directly from our local variable to minimize calls
-          local currentXPForSetting = stats[xpVariable]
+          local currentXPForSetting = stats[xpVariable] or 0
           local newXPForSetting = currentXPForSetting + xpGained
           stats[xpVariable] = newXPForSetting
           statsChanged = statsChanged + 1
@@ -127,8 +127,11 @@ xpTrackingFrame:RegisterEvent("ADDON_LOADED")
 xpTrackingFrame:SetScript("OnEvent", function(self, event, ...)
   if event == "PLAYER_REGEN_ENABLED" then
     AddonXPTracking:XPTrackingDebug("PLAYER_REGEN_ENABLED event fired")
-    C_Timer.After(2.0, function() 
+    C_Timer.After(3.0, function() 
       UpdateXPTracking(false)
+      if AddonXPTracking:ValidateTotalStoredXP() ~= true then
+        AddonXPTracking:PrintXPVerificationWarning()
+      end
     end)
   elseif event == "PLAYER_XP_UPDATE" then
     AddonXPTracking:XPTrackingDebug("PLAYER_XP_UPDATE event fired")

--- a/Settings/StatisticsTab.lua
+++ b/Settings/StatisticsTab.lua
@@ -965,11 +965,11 @@ function InitializeStatisticsTab()
     tooltipKey = 'playerJumps',
   }, {
     key = 'xpGWA',
-    label = 'XP With Addon:',
+    label = 'Verified XP:',
     tooltipKey = 'xpGWA',
   }, {
     key = 'xpGWOA',
-    label = 'XP Without Addon:',
+    label = 'Unverified XP:',
     tooltipKey = 'xpGWOA',
   }, {
     key = 'mapKeyPressesWhileMapBlocked',

--- a/UltraHardcore.toc
+++ b/UltraHardcore.toc
@@ -45,6 +45,7 @@ Functions/RoutePlannerCompass.lua
 Functions/GroupButtons.lua
 Functions/ExpBar.lua
 Functions/TradeRestriction.lua
+Functions/AddonXPTracking.lua
 
 Functions/Statistics/TrackLowestHealth.lua
 Functions/Statistics/TrackXPPerSetting.lua


### PR DESCRIPTION
I sent you a message in discord about some code I rewrote that perhaps you should read before inspecting what I've changed.

### Summary
- This extracts the logic for tracking addon XP from CharacterStats.lua and TrackXPPerSetting.lus as much as possible

### Screenshots / Video (optional)

Image showing verified status after hitting level 2, with correct Verified XP tracked:

<img width="1211" height="336" alt="Level 2 verified xp" src="https://github.com/user-attachments/assets/e85349ff-6af8-44a8-8a65-db778930344e" />

Image showing the output of /uhcxpreport after hitting level 2, exiting the game and logging back in:

<img width="323" height="131" alt="image" src="https://github.com/user-attachments/assets/367f557d-6eca-4713-bc56-97d3d41494de" />

Image showing verification failing after killing a mob with the addon disabled:

<img width="1149" height="235" alt="image" src="https://github.com/user-attachments/assets/0990e2c3-f026-4aee-b517-4c211badabb3" />


### Testing Steps (in-game)

How to enable/trigger the feature.

1. Level a new character from 1 to 2
2. Run /uhcxpreport 
3. Expected result:
   - Total XP should be the same as XP Gained With Addon
   - XP Gained Without Addon should be 0
   - The command should report your addon XP as fully verified

The XP tracking reset command is still available via `/uhcresettracking`

