### PR TITLE
Prevent zooming when tracking minimap overlay is up

### DIFF
--- a/Functions/SetMinimapDisplay.lua
+++ b/Functions/SetMinimapDisplay.lua
@@ -248,11 +248,9 @@ function HideMinimap(showClockEvenWhenMapHidden)
         end
       end
 
-
       -- Show only the minimap (keep cluster elements hidden)
       Minimap:Show()
       Minimap:SetZoom(0)
-
 
       -- Cancel any existing 'hide' timer
       if minimapHideTimer then

--- a/Functions/SetMinimapDisplay.lua
+++ b/Functions/SetMinimapDisplay.lua
@@ -207,6 +207,9 @@ function HideMinimap(showClockEvenWhenMapHidden)
       Minimap:SetScale(8.0)
       -- Minimap:SetAlpha(1)
 
+      -- Prevent zooming when showing our tracking
+      Minimap:EnableMouseWheel(false)
+
       -- Ensure we don't alter the minimap mask; rely on the game's default circular mask
 
       -- Hide extra minimap adornments while revealing
@@ -245,9 +248,13 @@ function HideMinimap(showClockEvenWhenMapHidden)
         end
       end
 
+
       -- Show only the minimap (keep cluster elements hidden)
       Minimap:Show()
       Minimap:SetZoom(0)
+
+      -- Prevent zooming when showing our tracking
+      Minimap:EnableMouseWheel(false)
 
       -- Cancel any existing 'hide' timer
       if minimapHideTimer then

--- a/Functions/SetMinimapDisplay.lua
+++ b/Functions/SetMinimapDisplay.lua
@@ -253,8 +253,6 @@ function HideMinimap(showClockEvenWhenMapHidden)
       Minimap:Show()
       Minimap:SetZoom(0)
 
-      -- Prevent zooming when showing our tracking
-      Minimap:EnableMouseWheel(false)
 
       -- Cancel any existing 'hide' timer
       if minimapHideTimer then


### PR DESCRIPTION
### Summary

Someone reported that they could zoom the minimap overlay that we show for the 5 seconds of tracking.

I personally like having zoom disabled when the overlay is up.  I have other abilities bound to mouse wheel up and down that break if I have my mouse over the tracking area while it is up.

### Testing Steps (in-game)

1. With hide minimap enabled track something, and for those 5 seconds, put your mouse over the center of the screen and use your mouse wheel.  It should no longer zoom the overlay.