### PR TITLE
Refactor Druid resource bar settings and drag functionality

### DIFF
--- a/Constants/PresetSections.lua
+++ b/Constants/PresetSections.lua
@@ -58,9 +58,9 @@ local PRESET_SECTIONS = { {
     'playPlayerDeathSoundbite',
     'spookyTunnelVision',
     'roachHearthstoneInPartyCombat',
-    'showDruidFormResourceBar',
-    'druidFormBarAnchorToResourceBar',
-  },
+      'showDruidFormResourceBar',
+      'druidFormBarAnchorToResourceBar',
+    },
 }, {
   title = 'XP Bar:',
   settings = { 'showExpBar', 'showXpBarToolTip', 'hideDefaultExpBar', 'xpBarHeight' },

--- a/Functions/Overlays/CustomResourceBar.lua
+++ b/Functions/Overlays/CustomResourceBar.lua
@@ -175,7 +175,7 @@ if not druidFormResourceBar then
   return
 end
 
-druidFormResourceBar:SetSize(225, PlayerFrameManaBar:GetHeight())
+druidFormResourceBar:SetSize(125, PlayerFrameManaBar:GetHeight() - 5)
 druidFormResourceBar:SetPoint('CENTER', UIParent, 'BOTTOM', 0, 20)
 druidFormResourceBar:SetStatusBarTexture('Interface\\TargetingFrame\\UI-StatusBar')
 druidFormResourceBar:Hide() -- Initially hidden
@@ -188,7 +188,7 @@ end
 
 druidFormBorder:SetTexture('Interface\\CastingBar\\UI-CastingBar-Border')
 druidFormBorder:SetPoint('CENTER', druidFormResourceBar, 'CENTER', 0, 0)
-druidFormBorder:SetSize(300, 64)
+druidFormBorder:SetSize(171, 50)
 
 -- Position persistence functions for druid form resource bar
 local function SaveDruidFormResourceBarPosition()
@@ -242,11 +242,22 @@ druidFormResourceBar:SetMovable(true)
 druidFormResourceBar:EnableMouse(true)
 druidFormResourceBar:RegisterForDrag('LeftButton')
 druidFormResourceBar:SetScript('OnDragStart', function(self)
-  self:StartMoving()
+  -- If anchored to resource bar, move the resource bar instead
+  if GLOBAL_SETTINGS and GLOBAL_SETTINGS.druidFormBarAnchorToResourceBar then
+    resourceBar:StartMoving()
+  else
+    self:StartMoving()
+  end
 end)
 druidFormResourceBar:SetScript('OnDragStop', function(self)
-  self:StopMovingOrSizing()
-  SaveDruidFormResourceBarPosition()
+  -- If anchored to resource bar, save resource bar position
+  if GLOBAL_SETTINGS and GLOBAL_SETTINGS.druidFormBarAnchorToResourceBar then
+    resourceBar:StopMovingOrSizing()
+    SaveResourceBarPosition()
+  else
+    self:StopMovingOrSizing()
+    SaveDruidFormResourceBarPosition()
+  end
 end)
 
 -- Unified function to update resource points


### PR DESCRIPTION
### Summary

- Fixes druid resource bar (mana bar) when in shapeshifted form

### Screenshots / Video (optional)

<img width="768" height="275" alt="image" src="https://github.com/user-attachments/assets/5d83ff2e-0b5a-4bf4-a2e3-c41809590c45" />
<img width="1139" height="204" alt="image" src="https://github.com/user-attachments/assets/a49e2c92-bbff-4883-a236-d1bfc5247d6b" />

<img width="951" height="411" alt="image" src="https://github.com/user-attachments/assets/c461ecd5-1cbe-4eb1-bc9d-9af9e0c2b291" />
<img width="1039" height="173" alt="image" src="https://github.com/user-attachments/assets/81b98be1-87cc-435a-9b51-2c215508c540" />


### Testing Steps (in-game)

you can use `/rrb` and `/resetresourcebar` to reset the position of the custom resource bar.
you can use `rrdb` and `/resetdruidformresourcebar` to reset the position of the mana druid bar.

