### PR TITLE
[Bug Fix] Fix for buff position reset when joining or leaving party

### DIFF
--- a/Functions/Overlays/CustomResourceBar.lua
+++ b/Functions/Overlays/CustomResourceBar.lua
@@ -542,6 +542,7 @@ resourceBar:RegisterEvent('GROUP_ROSTER_UPDATE')
 resourceBar:RegisterEvent('GROUP_JOINED')
 resourceBar:RegisterEvent('GROUP_LEFT')
 resourceBar:RegisterEvent('PLAYER_LOGIN')
+resourceBar:RegisterEvent('UNIT_INVENTORY_CHANGED')
 comboFrame:RegisterEvent('PLAYER_TARGET_CHANGED')
 
 -- Register druid form resource bar for events
@@ -655,8 +656,17 @@ resourceBar:SetScript('OnEvent', function(self, event, unit)
   elseif event == 'PET_ATTACK_START' or event == 'PET_ATTACK_STOP' then
     -- Update pet resource when pet starts/stops attacking
     UpdatePetResourcePoints()
-  elseif unit == 'player' and event == 'UNIT_AURA' or event == 'GROUP_ROSTER_UPDATE' or event == 'GROUP_JOINED' or event == 'GROUP_LEFT' then
+  elseif unit == 'player' and event == 'UNIT_AURA'
+          or event == 'GROUP_ROSTER_UPDATE'
+          or event == 'GROUP_JOINED'
+          or event == 'GROUP_LEFT' then
     CenterPlayerBuffBar()
+  elseif unit == 'player' and event == 'UNIT_INVENTORY_CHANGED' then
+    -- This event triggers based on inventory items changing so it needs a small delay
+    -- or the normal buffs end up in the BuffFrame instead of the custom frame.
+    C_Timer.After(0.1, function()
+      CenterPlayerBuffBar()
+    end)
   end
 end)
 

--- a/Functions/Overlays/CustomResourceBar.lua
+++ b/Functions/Overlays/CustomResourceBar.lua
@@ -535,6 +535,9 @@ resourceBar:RegisterEvent('UNIT_PET')
 resourceBar:RegisterEvent('PET_ATTACK_START')
 resourceBar:RegisterEvent('PET_ATTACK_STOP')
 resourceBar:RegisterEvent('UNIT_AURA')
+resourceBar:RegisterEvent('GROUP_ROSTER_UPDATE')
+resourceBar:RegisterEvent('GROUP_JOINED')
+resourceBar:RegisterEvent('GROUP_LEFT')
 resourceBar:RegisterEvent('PLAYER_LOGIN')
 comboFrame:RegisterEvent('PLAYER_TARGET_CHANGED')
 
@@ -649,7 +652,7 @@ resourceBar:SetScript('OnEvent', function(self, event, unit)
   elseif event == 'PET_ATTACK_START' or event == 'PET_ATTACK_STOP' then
     -- Update pet resource when pet starts/stops attacking
     UpdatePetResourcePoints()
-  elseif unit == 'player' and event == 'UNIT_AURA' then
+  elseif unit == 'player' and event == 'UNIT_AURA' or event == 'GROUP_ROSTER_UPDATE' or event == 'GROUP_JOINED' or event == 'GROUP_LEFT' then
     CenterPlayerBuffBar()
   end
 end)


### PR DESCRIPTION
### Summary

- Fixes the bug where buffs go back to top right when joining or leaving a party
- Also includes a fix for temporary weapon enchants to show up like normal buffs

### Screenshots

Example of multiple rows of buffs with item enchants active (testing with 2 buffs per row)

<img width="706" height="606" alt="2 buffs per row and 8 total buffs example" src="https://github.com/user-attachments/assets/f4d1e6b7-5417-478b-899a-66deb61bdcc8" />

Example of how this looks normally with 10 buffs per row

<img width="820" height="380" alt="image" src="https://github.com/user-attachments/assets/c05bc42e-8068-4ab4-a6d4-ce223ac1c60c" />


### Testing Steps (in-game)

How to enable/trigger the feature.

1. Ensure you have buffs on your character
   - Turn on the buffs over resource bar setting
   - Join a party
   - Leave the party
2. Apply a temporary weapon buff
   - Use poisons for rogue
   - Apply a sharpening stone or weighted stone depending on your weapon
   - Use a shaman weapon enchant
3. Expected result:
   - Buffs should stay above resource bar at all times

