### PR TITLE
Class Colored Raid Frames

### DIFF
--- a/Functions/HidePartyInformation.lua
+++ b/Functions/HidePartyInformation.lua
@@ -268,11 +268,23 @@ local function HookCompactRaidHealthHiding()
       if frame.uhcCircle.SetBlendMode then
         frame.uhcCircle:SetBlendMode('BLEND')
       end
-      if frame.uhcCircle.SetVertexColor then
-        frame.uhcCircle:SetVertexColor(0, 0, 0, 0.2)
-      else
-        frame.uhcCircle:SetAlpha(0.2)
-      end
+      -- Default color is black with low opacity
+      local r, g, b, a = 0, 0, 0, 0.2
+      -- Check if class colors are enabled and apply class color if available
+      -- Defensive against any of these methods not being available or returning unexpected values
+      local success, err = pcall(function()
+        local activeProfile = GetActiveRaidProfile()
+        local unit = frame.displayedUnit or frame.unit
+        if activeProfile and GetRaidProfileOption(activeProfile, 'useClassColors') and unit then
+          local _, englishClass = UnitClass(unit)
+          if englishClass then
+            local classR, classG, classB = GetClassColor(englishClass)
+            r, g, b, a = classR, classG, classB, .5
+          end
+        end
+      end)
+      -- If any error occurred, r, g, b, a will remain at default black values
+      frame.uhcCircle:SetVertexColor(r, g, b, a)
     end
     -- Size and position the circle to match the raid frame, and keep it updated
     UHC_UpdateRaidCircleAndIndicatorSizes(frame)

--- a/Functions/HidePartyInformation.lua
+++ b/Functions/HidePartyInformation.lua
@@ -278,8 +278,8 @@ local function HookCompactRaidHealthHiding()
         if activeProfile and GetRaidProfileOption(activeProfile, 'useClassColors') and unit then
           local _, englishClass = UnitClass(unit)
           if englishClass then
-            local classR, classG, classB = GetClassColor(englishClass)
-            r, g, b, a = classR, classG, classB, .5
+            r, g, b = GetClassColor(englishClass)
+            a = .4
           end
         end
       end)


### PR DESCRIPTION
### Summary

I was interested in a way to still see class colored frames with the ultra-style raid frames. I used to use player portraits to easily identify the tanks when healing (ie. the tank is a gnome so click the gnome). This allows for slightly easier identification when using raid style frames. It respects the Raid Profile setting that users are able to set in the main WoW settings.

### Screenshots / Video (optional)

<img width="253" height="320" alt="image" src="https://github.com/user-attachments/assets/3ca6beb9-3ae4-4d46-9af1-e9fe9fe9511b" />

### Testing Steps (in-game)
1. Join a party
2. Open Interface options and select "Display Class Colors"
3. Your frames should now be colored by class.

Edge Cases
1. Creating multiple Raid Profiles and swapping between them with different color settings.
2. Other Interface settings enabled
  - Borders, Power Bars, pets, etc.
3. HP Indicator visibility with druid / rogue colors.
