### PR TITLE
Update font size on raid party frames.

### DIFF
--- a/Functions/HidePartyInformation.lua
+++ b/Functions/HidePartyInformation.lua
@@ -355,10 +355,10 @@ local function HookCompactRaidHealthHiding()
       if nameFrame.GetFont and nameFrame.SetFont then
         local font, size, flags = nameFrame:GetFont()
         if size and size > 8 then
-          nameFrame:SetFont(font, math.max(8, size - 3), flags)
+          nameFrame:SetFont(font, math.max(10, size - 1), flags)
         end
       elseif nameFrame.SetTextHeight then
-        nameFrame:SetTextHeight(8)
+        nameFrame:SetTextHeight(10)
       end
     end
     -- Re-anchor and resize the health indicator to match the circle/frame


### PR DESCRIPTION
### Note
I spent way too long trying to make a low mana indicator that would replace the resource bars. Nothing I did I liked, so I scrapped it and just updated the font size ha.


### Summary
Names a bit bigger in raid style frames.

### Screenshots / Video (optional)
<img width="181" height="349" alt="image" src="https://github.com/user-attachments/assets/ee3d4381-79e8-4be9-bc2a-8af37dc2a489" />

### Testing Steps (in-game)

How to enable/trigger the feature.
Join a party with rade style frames.

