### PR TITLE
Target frame using alpha and allow buff, debuff, raid icon

### DIFF
--- a/Constants/PresetSections.lua
+++ b/Constants/PresetSections.lua
@@ -36,7 +36,9 @@ local PRESET_SECTIONS = { {
     'completelyRemovePlayerFrame',
     'completelyRemoveTargetFrame',
     'routePlannerCompass',
-    -- 'showTargetDebuffs',
+    'showTargetBuffs',
+    'showTargetDebuffs',
+    'showTargetRaidIcon',
   },
 }, {
   title = 'Misc:',

--- a/Functions/DB/LoadDBData.lua
+++ b/Functions/DB/LoadDBData.lua
@@ -49,7 +49,9 @@ function LoadDBData()
     completelyRemovePlayerFrame = false,
     completelyRemoveTargetFrame = false,
     routePlannerCompass = false,
-    -- showTargetDebuffs = false,
+    showTargetBuffs = false,
+    showTargetDebuffs = false,
+    showTargetRaidIcon = false,
     -- Misc Settings
     showOnScreenStatistics = true,
     minimapClockPosition = {},

--- a/Functions/SetTargetFrameDisplay.lua
+++ b/Functions/SetTargetFrameDisplay.lua
@@ -129,7 +129,7 @@ local function PositionAuras()
     local shownIndex = 0
 
     -- debuffs start below the last buff row
-    local baseYOffset = 15 - buffRowsUsed * (size + spacing) - spacing
+    local baseYOffset = 5 - buffRowsUsed * (size + spacing) - spacing
 
     for i = 1, maxDebuffs do
       local debuff = _G["TargetFrameDebuff"..i]

--- a/Functions/SetTargetFrameDisplay.lua
+++ b/Functions/SetTargetFrameDisplay.lua
@@ -37,7 +37,7 @@ local function HideTextureRegions(frame)
   for i = 1, select("#", frame:GetRegions()) do
     local region = select(i, frame:GetRegions())
     if region ~= TargetFramePortrait and
-       region ~= TargetFrameTextureFrameRaidTargetIcon then
+    region ~= TargetFrameTextureFrameRaidTargetIcon then
       region:SetAlpha(0)
     end
   end
@@ -90,34 +90,63 @@ local function ApplyAuras()
   end
 end
 
--- Position buffs and debuffs 
+-- Position buffs and debuffs
 local function PositionAuras()
   local spacing = 5 -- spacing between icons
   local size = 16   -- icon size
+  local maxPerRow = 10 -- how many buffs/debuffs before we start a new row - TODO:  make this configurable
 
   -- Buffs
+  local buffRowsUsed = 0
+
   if targetFrameMask.buffs then
-    local offset = 0
+    local shownIndex = 0
+
     for i = 1, maxBuffs do
       local buff = _G["TargetFrameBuff"..i]
       if buff and buff:IsShown() then
+        shownIndex = shownIndex + 1
+
+        local row = math.floor((shownIndex - 1) / maxPerRow)
+        local col = (shownIndex - 1) % maxPerRow
+
         buff:ClearAllPoints()
-        buff:SetPoint("LEFT", TargetFramePortrait, "RIGHT", offset + spacing, 10)
-        offset = offset + size + spacing
+        buff:SetPoint(
+          "LEFT",
+          TargetFramePortrait,
+          "RIGHT",
+          spacing + col * (size + spacing),
+          15 - row * (size + spacing)
+        )
+
+        buffRowsUsed = row + 1
       end
     end
   end
 
   -- Debuffs
   if targetFrameMask.debuffs then
-    local offset = 0
-    local startY = -size - spacing -- vertical offset below buffs
+    local shownIndex = 0
+
+    -- debuffs start below the last buff row
+    local baseYOffset = 15 - buffRowsUsed * (size + spacing) - spacing
+
     for i = 1, maxDebuffs do
       local debuff = _G["TargetFrameDebuff"..i]
       if debuff and debuff:IsShown() then
+        shownIndex = shownIndex + 1
+
+        local row = math.floor((shownIndex - 1) / maxPerRow)
+        local col = (shownIndex - 1) % maxPerRow
+
         debuff:ClearAllPoints()
-        debuff:SetPoint("LEFT", TargetFramePortrait, "RIGHT", offset + spacing, startY)
-        offset = offset + size + spacing
+        debuff:SetPoint(
+          "LEFT",
+          TargetFramePortrait,
+          "RIGHT",
+          spacing + col * (size + spacing),
+          baseYOffset - row * (size + spacing)
+        )
       end
     end
   end

--- a/Functions/SetTargetFrameDisplay.lua
+++ b/Functions/SetTargetFrameDisplay.lua
@@ -1,282 +1,215 @@
---[[
-  Removes health information (and power) from the target frames.
-  Uses the same logic as HidePartyInformation.lua
-]]
-
-TARGET_FRAME_SUBFRAMES_TO_HIDE =
-  {
-    'HealthBar',
-    'ManaBar',
-    'Texture',
-    'Background',
-    'LevelText',
-    'Name',
-    'NameBackground',
-    'StatusTexture',
-    'TextureFrameHealthBarText',
-    'TextureFrameManaBarText',
-    'NumericalThreat',
-    'Buff1',
-    'Buff2',
-    'Buff3',
-    'Buff4',
-    'Buff5',
-    'Buff6',
-    'Buff7',
-    'Buff8',
-    'Debuff1',
-    'Debuff2',
-    'Debuff3',
-    'Debuff4',
-    'Debuff5',
-    'Debuff6',
-    'Debuff7',
-    'Debuff8',
-  }
-
-TARGET_OF_TARGET_SUBFRAMES_TO_HIDE =
-  {
-    'HealthBar',
-    'ManaBar',
-    'Texture',
-    'Background',
-    'LevelText',
-    'Name',
-    'NameBackground',
-    'TextureFrameHealthBarText',
-    'TextureFrameManaBarText',
-    'Buff1',
-    'Buff2',
-    'Buff3',
-    'Buff4',
-    'Buff5',
-    'Buff6',
-    'Buff7',
-    'Buff8',
-    'Debuff1',
-    'Debuff2',
-    'Debuff3',
-    'Debuff4',
-    'Debuff5',
-    'Debuff6',
-    'Debuff7',
-    'Debuff8',
-  }
-
--- Global variable to track if target frame hiding is enabled
-local targetFrameHidingEnabled = false
+-- Global mask and event frame
+local targetFrameMask = {}
 local targetFrameEventFrame = nil
 
--- Immediate buff/debuff blocking - runs on addon load
-local function BlockBuffDebuffFrames()
-  -- Use a more targeted approach that doesn't override global CreateFrame
-  local function hideTargetBuffDebuffFrames()
-    for i = 1, 8 do
-      local buffFrame = _G['TargetFrameBuff' .. i]
-      if buffFrame then
-        buffFrame.Show = function() end
-        buffFrame:Hide()
-      end
-      local debuffFrame = _G['TargetFrameDebuff' .. i]
-      if debuffFrame then
-        debuffFrame.Show = function() end
-        debuffFrame:Hide()
+-- Buff Limits
+local maxBuffs = BUFF_MAX_DISPLAY or 32
+local maxDebuffs = DEBUFF_MAX_DISPLAY or 16
+
+-- Top-level frames that can be hidden
+local HIDEABLE_SUBFRAMES = {
+  "HealthBar",
+  "ManaBar",
+  "Name",
+  "NameBackground",
+  "HealthBarText",
+  "ManaBarText",
+  "Background"
+}
+
+-- TextureFrame children that Blizzard forcibly updates
+local TEXTURE_CHILD_FRAMES = {
+  "Name",
+  "ManaBarText",
+  "HealthBarText",
+  "StatusTexture",
+  "Background",
+}
+
+-- Hide all texture regions inside frame except portrait, raid icon
+local function HideTextureRegions(frame)
+  if not frame then return end
+  if targetFrameMask.all then
+    -- Don't hide if we are trying to show all frames, like when in lite mode
+    return
+  end
+
+  for i = 1, select("#", frame:GetRegions()) do
+    local region = select(i, frame:GetRegions())
+    if region ~= TargetFramePortrait and
+       region ~= TargetFrameTextureFrameRaidTargetIcon then
+      region:SetAlpha(0)
+    end
+  end
+end
+
+-- Apply alpha to hide subframes
+local function HideSubFrames(frame)
+  if targetFrameMask.all then
+    -- don't hide anything if we are trying to show all
+    return
+  end
+
+  for _, name in ipairs(HIDEABLE_SUBFRAMES) do
+    local f = _G[frame..name]
+    if f then
+      f:SetAlpha(0)
+    end
+  end
+
+  -- Inner TextureFrame children
+  for _, name in ipairs(TEXTURE_CHILD_FRAMES) do
+    local f = _G[frame.."TextureFrame"..name]
+    if f then
+      f:SetAlpha(0)
+    end
+  end
+end
+
+-- Show/hide portrait
+local function ApplyPortrait()
+  if TargetFramePortrait then
+    TargetFramePortrait:SetAlpha(targetFrameMask.portrait and 1 or 0)
+  end
+end
+
+-- Show/hide buffs/debuffs
+local function ApplyAuras()
+  for i = 1, maxBuffs do
+    local buff = _G["TargetFrameBuff"..i]
+    if buff then
+      buff:SetAlpha(targetFrameMask.buffs and 1 or 0)
+    end
+  end
+
+  for i = 1, maxDebuffs do
+    local debuff = _G["TargetFrameDebuff"..i]
+    if debuff then
+      debuff:SetAlpha(targetFrameMask.debuffs and 1 or 0)
+    end
+  end
+end
+
+-- Position buffs and debuffs 
+local function PositionAuras()
+  local spacing = 5 -- spacing between icons
+  local size = 16   -- icon size
+
+  -- Buffs
+  if targetFrameMask.buffs then
+    local offset = 0
+    for i = 1, maxBuffs do
+      local buff = _G["TargetFrameBuff"..i]
+      if buff and buff:IsShown() then
+        buff:ClearAllPoints()
+        buff:SetPoint("LEFT", TargetFramePortrait, "RIGHT", offset + spacing, 10)
+        offset = offset + size + spacing
       end
     end
   end
 
-  -- Hide frames immediately and set up periodic checking
-  hideTargetBuffDebuffFrames()
-
-  -- Set up a timer to periodically check and hide any new buff/debuff frames
-  local checkTimer = C_Timer.NewTicker(0.1, function()
-    hideTargetBuffDebuffFrames()
-  end)
-
-  -- Store the timer so we can stop it later if needed
-  _G.UltraHardcoreTargetFrameTimer = checkTimer
-end
-
--- Run the blocking immediately
-BlockBuffDebuffFrames()
-
-function SetTargetFrameDisplay(hideDetails, completelyRemove)
-  targetFrameHidingEnabled = hideDetails
-
-  if hideDetails then
-    if completelyRemove then
-      -- Completely hide the entire target frame
-      CompletelyHideTargetFrame()
-    else
-      SetTargetFrameInfo()
-      SetTargetOfTargetFrameInfo()
-
-      -- Create event frame to monitor target changes and buff/debuff updates
-      if not targetFrameEventFrame then
-        targetFrameEventFrame = CreateFrame('Frame')
-        targetFrameEventFrame:RegisterEvent('PLAYER_TARGET_CHANGED')
-        targetFrameEventFrame:RegisterEvent('UNIT_TARGET')
-        targetFrameEventFrame:RegisterEvent('UNIT_AURA')
-        targetFrameEventFrame:RegisterEvent('PLAYER_TARGET_CHANGED')
-        targetFrameEventFrame:SetScript('OnEvent', function(self, event, unit)
-          if targetFrameHidingEnabled then
-            if event == 'UNIT_AURA' and (unit == 'target' or unit == 'targettarget') then
-              -- Immediately hide buffs/debuffs when auras update
-              C_Timer.After(0.01, function()
-                for i = 1, 8 do
-                  local buffFrame = _G['TargetFrameBuff' .. i]
-                  if buffFrame then
-                    buffFrame:Hide()
-                    buffFrame.Show = function() end
-                  end
-                  local debuffFrame = _G['TargetFrameDebuff' .. i]
-                  if debuffFrame then
-                    debuffFrame:Hide()
-                    debuffFrame.Show = function() end
-                  end
-                end
-              end)
-            else
-              -- Small delay to ensure frames are created before hiding
-              C_Timer.After(0.1, function()
-                SetTargetFrameInfo()
-                SetTargetOfTargetFrameInfo()
-              end)
-            end
-          end
-        end)
+  -- Debuffs
+  if targetFrameMask.debuffs then
+    local offset = 0
+    local startY = -size - spacing -- vertical offset below buffs
+    for i = 1, maxDebuffs do
+      local debuff = _G["TargetFrameDebuff"..i]
+      if debuff and debuff:IsShown() then
+        debuff:ClearAllPoints()
+        debuff:SetPoint("LEFT", TargetFramePortrait, "RIGHT", offset + spacing, startY)
+        offset = offset + size + spacing
       end
     end
+  end
+end
+
+-- Show/hide raid icon
+local function ApplyRaidIcon()
+  if TargetFrameTextureFrameRaidTargetIcon then
+    TargetFrameTextureFrameRaidTargetIcon:SetAlpha(targetFrameMask.raidIcon and 1 or 0)
+  end
+end
+
+-- Showing Buffs/Debuffs on ToT can be a bit too much
+local function HideToTAuras()
+  for i = 1, maxBuffs do
+    local buff = _G["TargetFrameToTBuff"..i]
+    if buff then buff:SetAlpha(0) end
+  end
+  for i = 1, maxDebuffs do
+    local debuff = _G["TargetFrameToTDebuff"..i]
+    if debuff then debuff:SetAlpha(0) end
+  end
+end
+
+-- Show Target of Target if the user has turned it on in the blizzard options
+-- We will strip it down to just the portrait
+local function ShowToT()
+  if not TargetFrameToT then return end
+
+  if UnitExists("targettarget") then
+    TargetFrameToT:SetAlpha(1)
   else
-    if completelyRemove then
-      -- Completely restore the entire target frame
-      CompletelyShowTargetFrame()
-    else
-      RestoreTargetFrameInfo()
-      RestoreTargetOfTargetFrameInfo()
+    TargetFrameToT:SetAlpha(0)
+  end
+end
 
-      -- Clean up event frame
-      if targetFrameEventFrame then
-        targetFrameEventFrame:UnregisterAllEvents()
-        targetFrameEventFrame:SetScript('OnEvent', nil)
-        targetFrameEventFrame = nil
+-- Apply the full mask (combat-safe with alpha instead of Show/Hide)
+local function ApplyMask()
+  if TargetFrame then TargetFrame:SetAlpha(1) end
+  if TargetFrameTextureFrame then TargetFrameTextureFrame:SetAlpha(1) end
+
+  -- If mask is set to show all, do nothing (show Blizzard default frames)
+  if targetFrameMask.all then
+    -- still must update ToT visibility
+    ShowToT()
+    return
+  end
+
+  if not UnitExists("target") then
+    if TargetFrame then TargetFrame:SetAlpha(0) end
+    if TargetFrameTextureFrame then TargetFrameTextureFrame:SetAlpha(0) end
+    return
+  end
+
+  HideSubFrames("TargetFrame")
+  HideTextureRegions(TargetFrameTextureFrame)
+  ApplyPortrait()
+  ApplyRaidIcon()
+  ApplyAuras()
+  PositionAuras()
+end
+
+-- Hook Blizzard update functions
+hooksecurefunc("TargetFrame_CheckClassification", ApplyMask)
+hooksecurefunc("TargetFrame_Update", ApplyMask)
+hooksecurefunc("TargetFrame_UpdateAuras", ApplyMask)
+hooksecurefunc("TargetofTarget_Update", function()
+  C_Timer.After(0, function()
+    HideSubFrames("TargetFrameToT")
+    HideTextureRegions(TargetFrameToTTextureFrame)
+    HideToTAuras()
+    ShowToT()
+  end)
+end)
+
+
+-- Main API
+function SetTargetFrameDisplay(mask)
+  -- ensure mask is always a table
+  if type(mask) ~= "table" then mask = {} end
+  targetFrameMask = mask
+
+  if not targetFrameEventFrame then
+    targetFrameEventFrame = CreateFrame("Frame")
+    targetFrameEventFrame:RegisterEvent("PLAYER_TARGET_CHANGED")
+    targetFrameEventFrame:RegisterEvent("UNIT_AURA")
+    targetFrameEventFrame:RegisterEvent("RAID_TARGET_UPDATE")
+    targetFrameEventFrame:SetScript("OnEvent", function(_, event, unit)
+      if event == "PLAYER_TARGET_CHANGED" then
+        ApplyMask()
+        ShowToT()
       end
-
-      -- Stop the periodic timer for buff/debuff hiding
-      if _G.UltraHardcoreTargetFrameTimer then
-        _G.UltraHardcoreTargetFrameTimer:Cancel()
-        _G.UltraHardcoreTargetFrameTimer = nil
-      end
-    end
-  end
-end
-
-function SetTargetFrameInfo()
-  for _, subFrame in ipairs(TARGET_FRAME_SUBFRAMES_TO_HIDE) do
-    HideTargetSubFrame(subFrame)
-  end
-end
-
-function SetTargetOfTargetFrameInfo()
-  for _, subFrame in ipairs(TARGET_OF_TARGET_SUBFRAMES_TO_HIDE) do
-    HideTargetOfTargetSubFrame(subFrame)
-  end
-end
-
-function HideTargetSubFrame(subFrame)
-  local frame = _G['TargetFrame' .. subFrame]
-  if frame then
-    ForceHideFrame(frame)
-
-    -- For buff/debuff frames, also hook their creation to prevent them from ever showing
-    if string.match(subFrame, '^Buff%d+$') or string.match(subFrame, '^Debuff%d+$') then
-      -- Override the frame's Show method to do nothing
-      frame.Show = function() end
-      -- Also hook any potential parent frame creation
-      hooksecurefunc(frame, 'Show', function()
-        frame:Hide()
-      end)
-    end
-  end
-
-  -- Special case for TargetFrameTextureFrame
-  if subFrame == 'TextureFrameHealthBarText' or subFrame == 'TextureFrameManaBarText' then
-    local textureFrame = _G['TargetFrameTextureFrame']
-    if textureFrame then
-      ForceHideFrame(textureFrame)
-    end
-  end
-end
-
-function HideTargetOfTargetSubFrame(subFrame)
-  local frame = _G['TargetFrameToT' .. subFrame]
-  if frame then
-    ForceHideFrame(frame)
-
-    -- For buff/debuff frames, also hook their creation to prevent them from ever showing
-    if string.match(subFrame, '^Buff%d+$') or string.match(subFrame, '^Debuff%d+$') then
-      -- Override the frame's Show method to do nothing
-      frame.Show = function() end
-      -- Also hook any potential parent frame creation
-      hooksecurefunc(frame, 'Show', function()
-        frame:Hide()
-      end)
-    end
-  end
-end
-
-function CompletelyHideTargetFrame()
-  -- Hide the entire TargetFrame
-  if TargetFrame then
-    ForceHideFrame(TargetFrame)
-  end
-
-  -- Hide target of target frame
-  if TargetFrameToT then
-    ForceHideFrame(TargetFrameToT)
-  end
-
-  -- Stop the periodic timer for buff/debuff hiding since we're hiding everything
-  if _G.UltraHardcoreTargetFrameTimer then
-    _G.UltraHardcoreTargetFrameTimer:Cancel()
-    _G.UltraHardcoreTargetFrameTimer = nil
-  end
-end
-
-function CompletelyShowTargetFrame()
-  -- Show the entire TargetFrame
-  if TargetFrame then
-    RestoreAndShowFrame(TargetFrame)
-  end
-
-  -- Show target of target frame
-  if TargetFrameToT then
-    RestoreAndShowFrame(TargetFrameToT)
-  end
-end
-
-function RestoreTargetFrameInfo()
-  for _, subFrame in ipairs(TARGET_FRAME_SUBFRAMES_TO_HIDE) do
-    local frame = _G['TargetFrame' .. subFrame]
-    if frame then
-      RestoreAndShowFrame(frame)
-    end
-
-    -- Special case for TargetFrameTextureFrame
-    if subFrame == 'TextureFrameHealthBarText' or subFrame == 'TextureFrameManaBarText' then
-      local textureFrame = _G['TargetFrameTextureFrame']
-      if textureFrame then
-        RestoreAndShowFrame(textureFrame)
-      end
-    end
-  end
-end
-
-function RestoreTargetOfTargetFrameInfo()
-  for _, subFrame in ipairs(TARGET_OF_TARGET_SUBFRAMES_TO_HIDE) do
-    local frame = _G['TargetFrameToT' .. subFrame]
-    if frame then
-      RestoreAndShowFrame(frame)
-    end
+    end)
   end
 end

--- a/Settings/SettingsOptionsTab.lua
+++ b/Settings/SettingsOptionsTab.lua
@@ -9,9 +9,9 @@ local settingsCheckboxOptions = { {
   tooltip = 'The screen gets darker as you get closer to death',
 }, {
   -- Recommended Preset Settings
-  name = 'Hide Target Frame',
+  name = 'UHC Target Frame',
   dbSettingsValueName = 'hideTargetFrame',
-  tooltip = "Target frame is not visible, so you can't see the target's health or level",
+  tooltip = "Show UHC target frame, so you can't see the target's health or level",
 }, {
   name = 'Hide Target Tooltips',
   dbSettingsValueName = 'hideTargetTooltip',
@@ -90,6 +90,18 @@ local settingsCheckboxOptions = { {
   name = 'Completely Remove Target Frame',
   dbSettingsValueName = 'completelyRemoveTargetFrame',
   tooltip = 'Completely remove the target frame',
+}, {
+  name = 'Show Target Buffs',
+  dbSettingsValueName = 'showTargetBuffs',
+  tooltip = 'Show buffs on the target frame',
+}, {
+  name = 'Show Target Debuffs',
+  dbSettingsValueName = 'showTargetDebuffs',
+  tooltip = 'Show debuffs on the target frame',
+}, {
+  name = 'Show Target Raid Icon',
+  dbSettingsValueName = 'showTargetRaidIcon',
+  tooltip = 'Show raid icon on the target frame',
 }, {
   -- Misc Settings (no preset button)
   name = 'On Screen Statistics',
@@ -370,10 +382,6 @@ function InitializeSettingsOptionsTab()
     SetPlayerFrameDisplay(
       tempSettings.hidePlayerFrame or false,
       tempSettings.completelyRemovePlayerFrame or false
-    )
-    SetTargetFrameDisplay(
-      tempSettings.hideTargetFrame or false,
-      tempSettings.completelyRemoveTargetFrame or false
     )
 
     updateCheckboxes()
@@ -1132,10 +1140,11 @@ function InitializeSettingsOptionsTab()
       GLOBAL_SETTINGS.hidePlayerFrame or false,
       GLOBAL_SETTINGS.completelyRemovePlayerFrame or false
     )
-    SetTargetFrameDisplay(
-      GLOBAL_SETTINGS.hideTargetFrame or false,
-      GLOBAL_SETTINGS.completelyRemoveTargetFrame or false
-    )
+
+    -- Set target frame accordingly
+    if GLOBAL_SETTINGS.hideTargetFrame or GLOBAL_SETTINGS.completelyRemoveTargetFrame then
+      SetTargetFrameDisplay({})
+    end
 
     -- Handle XP Bar settings
     if GLOBAL_SETTINGS.showExpBar then

--- a/UltraHardcore.lua
+++ b/UltraHardcore.lua
@@ -26,10 +26,13 @@ UltraHardcore:RegisterEvent('UNIT_SPELLCAST_SUCCEEDED')
 UltraHardcore:RegisterEvent('UNIT_SPELLCAST_INTERRUPTED')
 UltraHardcore:RegisterEvent('CHAT_MSG_SYSTEM') -- Needed for duel winner and loser
 UltraHardcore:RegisterEvent('PLAYER_LOGOUT')
+UltraHardcore:RegisterEvent('PLAYER_LOGIN')
 
 -- 🟢 Event handler to apply all funcitons on login
 UltraHardcore:SetScript('OnEvent', function(self, event, ...)
-  if event == 'PLAYER_ENTERING_WORLD' or event == 'ADDON_LOADED' then
+  -- this was PLAYER_ENTERING_WORLD or ADDON_LOADED, but these are before all the UI elements are available.  
+  -- Switched to PLAYER_LOGIN which happens after ADDON_LOADED and all UI elements are available
+  if event == 'PLAYER_LOGIN' then
     LoadDBData()
     HidePlayerMapIndicators()
     ShowWelcomeMessage()
@@ -46,10 +49,25 @@ UltraHardcore:SetScript('OnEvent', function(self, event, ...)
     end
     SetMinimapDisplay(GLOBAL_SETTINGS.hideMinimap or false, miniMapMask)
     ShowResourceTrackingExplainer()
-    SetTargetFrameDisplay(
-      GLOBAL_SETTINGS.hideTargetFrame or false,
-      GLOBAL_SETTINGS.completelyRemoveTargetFrame or false
-    )
+
+    -- Setup target frame options
+    local targetMask = {}
+    if GLOBAL_SETTINGS.hideTargetFrame then
+      -- Hide target frame really means show our stripped down target frame instead of blizzard target frame
+      targetMask.portrait = true
+    else
+      -- show all elements (default target frame)
+      targetMask.all = true
+    end
+    targetMask.buffs = GLOBAL_SETTINGS.showTargetBuffs or false
+    targetMask.debuffs = GLOBAL_SETTINGS.showTargetDebuffs or false
+    targetMask.raidIcon = GLOBAL_SETTINGS.showTargetRaidIcon or false
+    if GLOBAL_SETTINGS.completelyRemoveTargetFrame then
+      -- An empty table will result in hiding everything
+      targetMask = {}
+    end
+    SetTargetFrameDisplay(targetMask)
+
     SetTargetTooltipDisplay(GLOBAL_SETTINGS.hideTargetTooltip or false)
     SetUIErrorsDisplay(GLOBAL_SETTINGS.hideUIErrors or false)
     SetActionBarVisibility(GLOBAL_SETTINGS.hideActionBars or false)


### PR DESCRIPTION
### Summary
- Changed target frame code to allow showing buff/debuff and raid icons
- Allow Target of Target frame (portrait only unless you are using Lite mode)
- Switched to SetAlpha for hiding.  This fixes the protected function error we see on first combat after a reload or login. 
- These changes also hide status text.  If we update the player frame to a similar setup we should be able to get rid of the forced cvar changes that disable status text.

### How to enable/trigger the feature.
Three new experimental options were added
- Show target buffs
- Show target debuffs
- show target raid icon

### Testing
- Tested combinations of all three options with and without the "Completely remove target frame" option.
- Tested Lite preset and verified the standard blizzard target frame and target of target frames work (if user has ToT enabled in blizzard options)
- Tested Recommended preset and verified UHC portrait for target and ToT are shown
