### PR TITLE
Fix default settings

### DIFF
--- a/Functions/DB/LoadDBData.lua
+++ b/Functions/DB/LoadDBData.lua
@@ -130,6 +130,14 @@ function LoadDBData()
     UltraHardcoreDB.characterSettings[characterGUID] = defaultSettings
   end
 
+  -- Iterate over the defaults to see if there are any new settings
+  -- we need to add to characters that have existing settings.
+  for settingName, settingValue in pairs(defaultSettings) do
+    if UltraHardcoreDB.characterSettings[characterGUID][settingName] == nil then
+      UltraHardcoreDB.characterSettings[characterGUID][settingName] = settingValue
+    end
+  end
+
   -- Load current character's settings
   GLOBAL_SETTINGS = UltraHardcoreDB.characterSettings[characterGUID]
 end

--- a/Functions/DB/LoadDBData.lua
+++ b/Functions/DB/LoadDBData.lua
@@ -75,6 +75,11 @@ function LoadDBData()
     guildSelfFound = false,
     groupSelfFound = false,
     showDruidFormResourceBar = true,
+    -- XP Bar
+    showExpBar = false,
+    showXpBarToolTip = false,
+    hideDefaultExpBar = false,
+    xpBarHeight = 3,
     -- Group Found teammate names (locked in at level 2)
     -- groupFoundNames = {},
     -- Statistics Row Visibility Settings
@@ -82,6 +87,10 @@ function LoadDBData()
     showMainStatisticsPanelLowestHealth = true,
     showMainStatisticsPanelSessionHealth = true,
     showMainStatisticsPanelThisLevel = false,
+    -- HP/Mana Totals
+    showMainStatisticsPanelTotalHP = false,
+    showMainStatisticsPanelTotalMana = false,
+    -- Fighting stats
     showMainStatisticsPanelEnemiesSlain = true,
     showMainStatisticsPanelDungeonsCompleted = false,
     showMainStatisticsPanelPetDeaths = false,
@@ -123,8 +132,4 @@ function LoadDBData()
 
   -- Load current character's settings
   GLOBAL_SETTINGS = UltraHardcoreDB.characterSettings[characterGUID]
-
-  if GLOBAL_SETTINGS.autoJoinUHCChannel == nil then
-    GLOBAL_SETTINGS.autoJoinUHCChannel = true
-  end
 end

--- a/Functions/DB/LoadDBData.lua
+++ b/Functions/DB/LoadDBData.lua
@@ -131,7 +131,7 @@ function LoadDBData()
   end
 
   -- Iterate over the defaults to see if there are any new settings
-  -- we need to add to characters that have existing settings.
+  -- we need to add to characters that have an existing DB.
   for settingName, settingValue in pairs(defaultSettings) do
     if UltraHardcoreDB.characterSettings[characterGUID][settingName] == nil then
       UltraHardcoreDB.characterSettings[characterGUID][settingName] = settingValue

--- a/Functions/Overlays/MainScreenStatistics.lua
+++ b/Functions/Overlays/MainScreenStatistics.lua
@@ -487,14 +487,7 @@ local function UpdateRowVisibility()
       -- Use the actual setting value
       isVisible = GLOBAL_SETTINGS[element.setting]
     else
-      -- Apply default behavior based on the setting
-      if element.setting == 'showMainStatisticsPanelLevel' or element.setting == 'showMainStatisticsPanelLowestHealth' or element.setting == 'showMainStatisticsPanelEnemiesSlain' or element.setting == 'showMainStatisticsPanelDungeonsCompleted' or element.setting == 'showMainStatisticsPanelHighestCritValue' or element.setting == 'showMainStatisticsPanelCloseEscapes' then
-        -- These default to true (show unless explicitly false)
-        isVisible = true
-      else
-        -- These default to false (hide unless explicitly true)
-        isVisible = false
-      end
+      isVisible = false
     end
 
     if isVisible then

--- a/Settings/Settings.lua
+++ b/Settings/Settings.lua
@@ -16,11 +16,7 @@ local function shouldRadioBeChecked(settingName, settings)
   if settings[settingName] ~= nil then
     return settings[settingName]
   else
-    if settingName == 'showMainStatisticsPanelLevel' or settingName == 'showMainStatisticsPanelLowestHealth' or settingName == 'showMainStatisticsPanelEnemiesSlain' or settingName == 'showMainStatisticsPanelDungeonsCompleted' or settingName == 'showMainStatisticsPanelHighestCritValue' or settingName == 'showMainStatisticsPanelCloseEscapes' then
-      return true
-    else
-      return false
-    end
+    return false
   end
 end
 

--- a/Settings/Settings.lua
+++ b/Settings/Settings.lua
@@ -37,20 +37,6 @@ local function initializeTempSettings()
       tempSettings[settingName] = shouldRadioBeChecked(settingName, GLOBAL_SETTINGS)
     end
   end
-
-  -- Initialize checkbox defaults for settings that don't exist
-  if tempSettings.showExpBar == nil then
-    tempSettings.showExpBar = false -- Default to off
-  end
-  if tempSettings.showXpBarToolTip == nil then
-    tempSettings.showXpBarToolTip = false -- Default to off (hide tooltip)
-  end
-  if tempSettings.hideDefaultExpBar == nil then
-    tempSettings.hideDefaultExpBar = false -- Default to off (show default XP bar)
-  end
-  if tempSettings.xpBarHeight == nil then
-    tempSettings.xpBarHeight = 3 -- Default height
-  end
 end
 
 local CLASS_BACKGROUND_MAP = {


### PR DESCRIPTION
### Summary

- Total HP / Mana are displayed by default on the on-screen statistics even though they are not turned on in stats.
- XP Bar default settings were being set outside of the normal default settings.
- Auto Join UHC was being set twice.  Removed the duplication.
- Added a check for new defaultSettings that do not exist in characters that already have an UltraHardcoreDB.characterSettings, and added them to their existing DB.
- Removed code that was hard-coding some on-screen stats.  My guess is this was a band-aid we had before we fixed the timing on when LoadDB was getting called,

### Testing Steps (in-game)

Verified that new character defaults are correctly set and displayed.
Verified that old character settings are correctly preserved.