### PR TITLE
Fix intermittent error for ToT frame when leaving combat

### DIFF
--- a/Functions/SetTargetFrameDisplay.lua
+++ b/Functions/SetTargetFrameDisplay.lua
@@ -214,12 +214,10 @@ hooksecurefunc("TargetFrame_CheckClassification", ApplyMask)
 hooksecurefunc("TargetFrame_Update", ApplyMask)
 hooksecurefunc("TargetFrame_UpdateAuras", ApplyMask)
 hooksecurefunc("TargetofTarget_Update", function()
-  C_Timer.After(0, function()
-    HideSubFrames("TargetFrameToT")
-    HideTextureRegions(TargetFrameToTTextureFrame)
-    HideToTAuras()
-    ShowToT()
-  end)
+  HideSubFrames("TargetFrameToT")
+  HideTextureRegions(TargetFrameToTTextureFrame)
+  HideToTAuras()
+  ShowToT()
 end)
 
 
@@ -237,7 +235,6 @@ function SetTargetFrameDisplay(mask)
     targetFrameEventFrame:SetScript("OnEvent", function(_, event, unit)
       if event == "PLAYER_TARGET_CHANGED" then
         ApplyMask()
-        ShowToT()
       end
     end)
   end


### PR DESCRIPTION
### Summary

I was occasionally hitting the protected function error for the ToT frame after leaving combat.  This appears to have fixed in my 15 minutes of fighting, but since it was intermittent, I cannot be 100% sure.

### Testing Steps (in-game)

Fight mobs with the Blizzard Target of Target option turned on.

- No target and face pull
- Target and range pull
- Switching targets in combat
