### PR TITLE
Fix target bar showing when inviting.

### DIFF
--- a/Functions/SetTargetFrameDisplay.lua
+++ b/Functions/SetTargetFrameDisplay.lua
@@ -232,8 +232,9 @@ function SetTargetFrameDisplay(mask)
     targetFrameEventFrame:RegisterEvent("PLAYER_TARGET_CHANGED")
     targetFrameEventFrame:RegisterEvent("UNIT_AURA")
     targetFrameEventFrame:RegisterEvent("RAID_TARGET_UPDATE")
+    targetFrameEventFrame:RegisterEvent("GROUP_ROSTER_UPDATE")
     targetFrameEventFrame:SetScript("OnEvent", function(_, event, unit)
-      if event == "PLAYER_TARGET_CHANGED" then
+      if event == "PLAYER_TARGET_CHANGED" or event == "GROUP_ROSTER_UPDATE" then
         ApplyMask()
       end
     end)


### PR DESCRIPTION
### Summary

Fixed an issue when grouping that would show a bar on the target frame.

### Testing Steps (in-game)

1. Have someone targeted and invite them to a group.  You should no longer see a bar on the target frame.