### PR TITLE
Fix TargetOfTarget Taint

### DIFF
--- a/Functions/SetPlayerFrameDisplay.lua
+++ b/Functions/SetPlayerFrameDisplay.lua
@@ -97,11 +97,6 @@ local function HidePlayerFrameHealthMana()
     PetAttackModeTexture:SetAlpha(0)
   end
 
-  -- Hide target frame health/mana bars
-  if TargetFrameToT then
-    TargetFrameToT:SetAlpha(0)
-  end
-
   -- Keep main XP bar normal (no modifications)
 
   -- Hide HP/mana text in character panel that overlaps with our XP bars
@@ -167,11 +162,6 @@ local function ShowPlayerFrameHealthMana()
   -- Restore pet attack mode texture
   if PetAttackModeTexture then
     RestoreAndShowFrame(PetAttackModeTexture)
-  end
-
-  -- Show target frame health/mana bars
-  if TargetFrameToT then
-    RestoreAndShowFrame(TargetFrameToT)
   end
 
   -- Keep main XP bar normal (no modifications needed)
@@ -241,11 +231,6 @@ function CompletelyHidePlayerFrame()
   if PetFrame then
     ForceHideFrame(PetFrame)
   end
-
-  -- Hide target of target frame
-  if TargetFrameToT then
-    ForceHideFrame(TargetFrameToT)
-  end
 end
 
 function CompletelyShowPlayerFrame()
@@ -257,11 +242,6 @@ function CompletelyShowPlayerFrame()
   -- Show pet frame as well
   if PetFrame then
     RestoreAndShowFrame(PetFrame)
-  end
-
-  -- Show target of target frame
-  if TargetFrameToT then
-    RestoreAndShowFrame(TargetFrameToT)
   end
 end
 

--- a/Functions/SetTargetFrameDisplay.lua
+++ b/Functions/SetTargetFrameDisplay.lua
@@ -184,10 +184,12 @@ local function SetupHooks()
     -- Always allow default alpha/visibility
     if not TargetFrameToT:IsProtected() then
       TargetFrameToT:SetAlpha(1)
-      -- Strip subframes/texture
-      HideSubFrames("TargetFrameToT")
     end
-    if TargetFrameToTTextureFrame and not TargetFrameToTTextureFrame:IsProtected() then
+
+    -- Strip subframes/texture
+    HideSubFrames("TargetFrameToT")
+
+    if TargetFrameToTTextureFrame then
       HideTextureRegions(TargetFrameToTTextureFrame)
     end
     -- Always hide auras (regardless of ToT existence)

--- a/Functions/SetTargetFrameDisplay.lua
+++ b/Functions/SetTargetFrameDisplay.lua
@@ -210,9 +210,12 @@ end
 local f = CreateFrame("Frame")
 f:RegisterEvent("PLAYER_ENTERING_WORLD")
 f:SetScript("OnEvent", function(self)
-    -- Safe because Blizzard has finished secure setup
-    InitToTPostSetup()
-    SetupHooks()
+     -- Delayed to ensure frame is properly setup
+    C_Timer.After(1, function()
+      -- Safe because Blizzard has finished secure setup
+      InitToTPostSetup()
+      SetupHooks()
+    end)
     self:UnregisterEvent("PLAYER_ENTERING_WORLD") -- only needed once
 end)
 

--- a/Functions/SetTargetFrameDisplay.lua
+++ b/Functions/SetTargetFrameDisplay.lua
@@ -157,19 +157,10 @@ end
 -- We will strip it down to just the portrait
 local function ShowToT()
   if not TargetFrameToT then return end
-
-  if UnitExists("targettarget") then
     -- allow Blizzard to show ToT normally
-    TargetFrameToT:SetAlpha(1)
-    if TargetFrameToTTextureFrame then
-      TargetFrameToTTextureFrame:SetAlpha(1)
-    end
-  else
-    -- hide it cleanly when no ToT exists
-    TargetFrameToT:SetAlpha(0)
-    if TargetFrameToTTextureFrame then
-      TargetFrameToTTextureFrame:SetAlpha(0)
-    end
+  TargetFrameToT:SetAlpha(1)
+  if TargetFrameToTTextureFrame then
+    TargetFrameToTTextureFrame:SetAlpha(1)
   end
 end
 
@@ -202,20 +193,18 @@ end
 -- Hook Blizzard update functions
 hooksecurefunc("TargetFrame_Update", ApplyMask)
 hooksecurefunc("TargetFrame_UpdateAuras", ApplyMask)
--- Target of Target hook
+  -- Target of Target hook (NO existence checks, NO visibility logic)
 hooksecurefunc("TargetofTarget_Update", function()
-  if UnitExists("targettarget") then
-    -- allow ToT to show, then apply cosmetic stripping
-    TargetFrameToT:SetAlpha(1)
-    HideSubFrames("TargetFrameToT")
-    if TargetFrameToTTextureFrame then
-        HideTextureRegions(TargetFrameToTTextureFrame)
-    end
-    HideToTAuras()
-  else
-    -- hide entire ToT in one step; no need to strip anything
-    TargetFrameToT:SetAlpha(0)
+  -- Always allow default alpha/visibility
+  TargetFrameToT:SetAlpha(1)
+
+  -- Strip subframes/texture
+  HideSubFrames("TargetFrameToT")
+  if TargetFrameToTTextureFrame then
+    HideTextureRegions(TargetFrameToTTextureFrame)
   end
+  -- Always hide auras (regardless of ToT existence)
+  HideToTAuras()
 end)
 
 

--- a/Functions/SetTargetFrameDisplay.lua
+++ b/Functions/SetTargetFrameDisplay.lua
@@ -181,9 +181,15 @@ local function SetupHooks()
   hooksecurefunc("TargetFrame_UpdateAuras", ApplyMask)
     -- Target of Target hook (NO existence checks, NO visibility logic)
   hooksecurefunc("TargetofTarget_Update", function()
+    -- Always allow default alpha/visibility
+    if not TargetFrameToT:IsProtected() then
+      TargetFrameToT:SetAlpha(1)
+    end
     -- Strip subframes/texture
     HideSubFrames("TargetFrameToT")
-    HideTextureRegions(TargetFrameToTTextureFrame)
+    if TargetFrameToTTextureFrame then
+      HideTextureRegions(TargetFrameToTTextureFrame)
+    end
     -- Always hide auras (regardless of ToT existence)
     HideToTAuras()
   end)
@@ -203,8 +209,8 @@ local f = CreateFrame("Frame")
 f:RegisterEvent("PLAYER_ENTERING_WORLD")
 f:SetScript("OnEvent", function(self)
     -- Safe because Blizzard has finished secure setup
-    InitToTPostSetup()
     SetupHooks()
+    InitToTPostSetup()
     self:UnregisterEvent("PLAYER_ENTERING_WORLD") -- only needed once
 end)
 

--- a/Functions/SetTargetFrameDisplay.lua
+++ b/Functions/SetTargetFrameDisplay.lua
@@ -184,10 +184,10 @@ local function SetupHooks()
     -- Always allow default alpha/visibility
     if not TargetFrameToT:IsProtected() then
       TargetFrameToT:SetAlpha(1)
+      -- Strip subframes/texture
+      HideSubFrames("TargetFrameToT")
     end
-    -- Strip subframes/texture
-    HideSubFrames("TargetFrameToT")
-    if TargetFrameToTTextureFrame then
+    if TargetFrameToTTextureFrame and not TargetFrameToTTextureFrame:IsProtected() then
       HideTextureRegions(TargetFrameToTTextureFrame)
     end
     -- Always hide auras (regardless of ToT existence)
@@ -196,10 +196,10 @@ local function SetupHooks()
 end
 
 local function InitToTPostSetup()
-  if TargetFrameToT then
+  if TargetFrameToT and not TargetFrameToT:IsProtected() then
       TargetFrameToT:SetAlpha(1)
   end
-  if TargetFrameToTTextureFrame then
+  if TargetFrameToTTextureFrame and not TargetFrameToTTextureFrame:IsProtected() then
       TargetFrameToTTextureFrame:SetAlpha(1)
   end
 end
@@ -209,8 +209,8 @@ local f = CreateFrame("Frame")
 f:RegisterEvent("PLAYER_ENTERING_WORLD")
 f:SetScript("OnEvent", function(self)
     -- Safe because Blizzard has finished secure setup
-    SetupHooks()
     InitToTPostSetup()
+    SetupHooks()
     self:UnregisterEvent("PLAYER_ENTERING_WORLD") -- only needed once
 end)
 

--- a/Functions/SetTargetFrameDisplay.lua
+++ b/Functions/SetTargetFrameDisplay.lua
@@ -27,7 +27,7 @@ local function HideTextureRegions(frame)
 
   for i = 1, select("#", frame:GetRegions()) do
     local region = select(i, frame:GetRegions())
-    if region then
+    if region and not region:IsProtected() then
       region:SetAlpha(0)
     end
   end
@@ -158,9 +158,11 @@ end
 local function ShowToT()
   if not TargetFrameToT then return end
     -- allow Blizzard to show ToT normally
-  TargetFrameToT:SetAlpha(1)
-  if TargetFrameToTTextureFrame then
-    TargetFrameToTTextureFrame:SetAlpha(1)
+  if not InCombatLockdown() then
+    TargetFrameToT:SetAlpha(1)
+    if TargetFrameToTTextureFrame then
+      TargetFrameToTTextureFrame:SetAlpha(1)
+    end
   end
 end
 


### PR DESCRIPTION
### Summary

Attempting to fix the occasional protected function call for TargetOfTarget:Show().
Also removed child frame loops that were not affecting visibility.  They were left over from initial PoC testing.

Issue:
Calling UnitExists("targettarget") inside the ToT hook.  Blizzard’s visibility driver already checks this.  Doing your own check inside the hook causes taint when Blizzard later tries to Show() the frame during combat.

Since this doesn't always happen, I still don't know if this is fixed 100%, but I haven't hit the issue again in my testing.

### Testing Steps (in-game)

Enable Blizzard's Target of Target in the options and kill stuff. :)
