### PR TITLE
Fix Target of Target protected function errors

### DIFF
--- a/Constants/PresetSections.lua
+++ b/Constants/PresetSections.lua
@@ -36,6 +36,7 @@ local PRESET_SECTIONS = { {
     'completelyRemovePlayerFrame',
     'completelyRemoveTargetFrame',
     'routePlannerCompass',
+    'showTargetOfTarget',
     'showTargetBuffs',
     'showTargetDebuffs',
     'showTargetRaidIcon',

--- a/Functions/DB/LoadDBData.lua
+++ b/Functions/DB/LoadDBData.lua
@@ -56,6 +56,7 @@ function LoadDBData()
     -- Misc Settings
     showTargetOfTargetPosition = {},
     showTargetOfTargetScale = 1.0,
+    showTargetOfTargetLocked = false,
     showOnScreenStatistics = true,
     minimapClockPosition = {},
     minimapMailPosition = {},

--- a/Functions/DB/LoadDBData.lua
+++ b/Functions/DB/LoadDBData.lua
@@ -49,10 +49,13 @@ function LoadDBData()
     completelyRemovePlayerFrame = false,
     completelyRemoveTargetFrame = false,
     routePlannerCompass = false,
+    showTargetOfTarget = false,
     showTargetBuffs = false,
     showTargetDebuffs = false,
     showTargetRaidIcon = false,
     -- Misc Settings
+    showTargetOfTargetPosition = {},
+    showTargetOfTargetScale = 1.0,
     showOnScreenStatistics = true,
     minimapClockPosition = {},
     minimapMailPosition = {},

--- a/Functions/SetPlayerFrameDisplay.lua
+++ b/Functions/SetPlayerFrameDisplay.lua
@@ -97,11 +97,6 @@ local function HidePlayerFrameHealthMana()
     PetAttackModeTexture:SetAlpha(0)
   end
 
-  -- Hide target frame health/mana bars
-  if TargetFrameToT then
-    TargetFrameToT:SetAlpha(0)
-  end
-
   -- Keep main XP bar normal (no modifications)
 
   -- Hide HP/mana text in character panel that overlaps with our XP bars
@@ -167,11 +162,6 @@ local function ShowPlayerFrameHealthMana()
   -- Restore pet attack mode texture
   if PetAttackModeTexture then
     RestoreAndShowFrame(PetAttackModeTexture)
-  end
-
-  -- Show target frame health/mana bars
-  if TargetFrameToT then
-    RestoreAndShowFrame(TargetFrameToT)
   end
 
   -- Keep main XP bar normal (no modifications needed)
@@ -241,11 +231,6 @@ function CompletelyHidePlayerFrame()
   if PetFrame then
     ForceHideFrame(PetFrame)
   end
-
-  -- Hide target of target frame
-  if TargetFrameToT then
-    ForceHideFrame(TargetFrameToT)
-  end
 end
 
 function CompletelyShowPlayerFrame()
@@ -257,11 +242,6 @@ function CompletelyShowPlayerFrame()
   -- Show pet frame as well
   if PetFrame then
     RestoreAndShowFrame(PetFrame)
-  end
-
-  -- Show target of target frame
-  if TargetFrameToT then
-    RestoreAndShowFrame(TargetFrameToT)
   end
 end
 

--- a/Functions/SetTargetFrameDisplay.lua
+++ b/Functions/SetTargetFrameDisplay.lua
@@ -184,10 +184,12 @@ local function SetupHooks()
     -- Always allow default alpha/visibility
     if not TargetFrameToT:IsProtected() then
       TargetFrameToT:SetAlpha(1)
-      -- Strip subframes/texture
-      HideSubFrames("TargetFrameToT")
     end
-    if TargetFrameToTTextureFrame and not TargetFrameToTTextureFrame:IsProtected() then
+
+    -- Strip subframes/texture
+    HideSubFrames("TargetFrameToT")
+
+    if TargetFrameToTTextureFrame then
       HideTextureRegions(TargetFrameToTTextureFrame)
     end
     -- Always hide auras (regardless of ToT existence)

--- a/Functions/SetTargetFrameDisplay.lua
+++ b/Functions/SetTargetFrameDisplay.lua
@@ -141,18 +141,6 @@ local function ApplyRaidIcon()
   end
 end
 
--- Showing Buffs/Debuffs on ToT can be a bit too much
-local function HideToTAuras()
-  for i = 1, maxBuffs do
-    local buff = _G["TargetFrameToTBuff"..i]
-    if buff then buff:SetAlpha(0) end
-  end
-  for i = 1, maxDebuffs do
-    local debuff = _G["TargetFrameToTDebuff"..i]
-    if debuff then debuff:SetAlpha(0) end
-  end
-end
-
 -- Apply the full mask (combat-safe with alpha instead of Show/Hide)
 local function ApplyMask()
   if TargetFrame then TargetFrame:SetAlpha(1) end
@@ -175,50 +163,8 @@ local function ApplyMask()
   PositionAuras()
 end
 
-local function SetupHooks()
-  -- Hook Blizzard update functions
-  hooksecurefunc("TargetFrame_Update", ApplyMask)
-  hooksecurefunc("TargetFrame_UpdateAuras", ApplyMask)
-    -- Target of Target hook (NO existence checks, NO visibility logic)
-  hooksecurefunc("TargetofTarget_Update", function()
-    -- Always allow default alpha/visibility
-    if not TargetFrameToT:IsProtected() then
-      TargetFrameToT:SetAlpha(1)
-    end
-
-    -- Strip subframes/texture
-    HideSubFrames("TargetFrameToT")
-
-    if TargetFrameToTTextureFrame then
-      HideTextureRegions(TargetFrameToTTextureFrame)
-    end
-    -- Always hide auras (regardless of ToT existence)
-    HideToTAuras()
-  end)
-end
-
-local function InitToTPostSetup()
-  if TargetFrameToT and not TargetFrameToT:IsProtected() then
-      TargetFrameToT:SetAlpha(1)
-  end
-  if TargetFrameToTTextureFrame and not TargetFrameToTTextureFrame:IsProtected() then
-      TargetFrameToTTextureFrame:SetAlpha(1)
-  end
-end
-
--- Run *after* Blizzard finishes secure frame creation
-local f = CreateFrame("Frame")
-f:RegisterEvent("PLAYER_ENTERING_WORLD")
-f:SetScript("OnEvent", function(self)
-     -- Delayed to ensure frame is properly setup
-    C_Timer.After(1, function()
-      -- Safe because Blizzard has finished secure setup
-      InitToTPostSetup()
-      SetupHooks()
-    end)
-    self:UnregisterEvent("PLAYER_ENTERING_WORLD") -- only needed once
-end)
-
+hooksecurefunc("TargetFrame_Update", ApplyMask)
+hooksecurefunc("TargetFrame_UpdateAuras", ApplyMask)
 
 -- Main API
 function SetTargetFrameDisplay(mask)

--- a/Functions/SetTargetFrameDisplay.lua
+++ b/Functions/SetTargetFrameDisplay.lua
@@ -210,9 +210,12 @@ end
 local f = CreateFrame("Frame")
 f:RegisterEvent("PLAYER_ENTERING_WORLD")
 f:SetScript("OnEvent", function(self)
-    -- Safe because Blizzard has finished secure setup
-    InitToTPostSetup()
-    SetupHooks()
+     -- Delayed to ensure frame is properly setup
+    C_Timer.After(1, function()
+      -- Safe because Blizzard has finished secure setup
+      InitToTPostSetup()
+      SetupHooks()
+    end)
     self:UnregisterEvent("PLAYER_ENTERING_WORLD") -- only needed once
 end)
 

--- a/Functions/SetTargetFrameDisplay.lua
+++ b/Functions/SetTargetFrameDisplay.lua
@@ -157,19 +157,10 @@ end
 -- We will strip it down to just the portrait
 local function ShowToT()
   if not TargetFrameToT then return end
-
-  if UnitExists("targettarget") then
     -- allow Blizzard to show ToT normally
-    TargetFrameToT:SetAlpha(1)
-    if TargetFrameToTTextureFrame then
-      TargetFrameToTTextureFrame:SetAlpha(1)
-    end
-  else
-    -- hide it cleanly when no ToT exists
-    TargetFrameToT:SetAlpha(0)
-    if TargetFrameToTTextureFrame then
-      TargetFrameToTTextureFrame:SetAlpha(0)
-    end
+  TargetFrameToT:SetAlpha(1)
+  if TargetFrameToTTextureFrame then
+    TargetFrameToTTextureFrame:SetAlpha(1)
   end
 end
 
@@ -202,20 +193,18 @@ end
 -- Hook Blizzard update functions
 hooksecurefunc("TargetFrame_Update", ApplyMask)
 hooksecurefunc("TargetFrame_UpdateAuras", ApplyMask)
--- Target of Target hook
+  -- Target of Target hook (NO existence checks, NO visibility logic)
 hooksecurefunc("TargetofTarget_Update", function()
-  if UnitExists("targettarget") then
-    -- allow ToT to show, then apply cosmetic stripping
-    TargetFrameToT:SetAlpha(1)
-    HideSubFrames("TargetFrameToT")
-    if TargetFrameToTTextureFrame then
-        HideTextureRegions(TargetFrameToTTextureFrame)
-    end
-    HideToTAuras()
-  else
-    -- hide entire ToT in one step; no need to strip anything
-    TargetFrameToT:SetAlpha(0)
+  -- Always allow default alpha/visibility
+  TargetFrameToT:SetAlpha(1)
+
+  -- Strip subframes/texture
+  HideSubFrames("TargetFrameToT")
+  if TargetFrameToTTextureFrame then
+    HideTextureRegions(TargetFrameToTTextureFrame)
   end
+  -- Always hide auras (regardless of ToT existence)
+  HideToTAuras()
 end)
 
 

--- a/Functions/SetTargetFrameDisplay.lua
+++ b/Functions/SetTargetFrameDisplay.lua
@@ -181,9 +181,15 @@ local function SetupHooks()
   hooksecurefunc("TargetFrame_UpdateAuras", ApplyMask)
     -- Target of Target hook (NO existence checks, NO visibility logic)
   hooksecurefunc("TargetofTarget_Update", function()
+    -- Always allow default alpha/visibility
+    if not TargetFrameToT:IsProtected() then
+      TargetFrameToT:SetAlpha(1)
+    end
     -- Strip subframes/texture
     HideSubFrames("TargetFrameToT")
-    HideTextureRegions(TargetFrameToTTextureFrame)
+    if TargetFrameToTTextureFrame then
+      HideTextureRegions(TargetFrameToTTextureFrame)
+    end
     -- Always hide auras (regardless of ToT existence)
     HideToTAuras()
   end)
@@ -203,8 +209,8 @@ local f = CreateFrame("Frame")
 f:RegisterEvent("PLAYER_ENTERING_WORLD")
 f:SetScript("OnEvent", function(self)
     -- Safe because Blizzard has finished secure setup
-    InitToTPostSetup()
     SetupHooks()
+    InitToTPostSetup()
     self:UnregisterEvent("PLAYER_ENTERING_WORLD") -- only needed once
 end)
 

--- a/Functions/SetTargetFrameDisplay.lua
+++ b/Functions/SetTargetFrameDisplay.lua
@@ -184,10 +184,10 @@ local function SetupHooks()
     -- Always allow default alpha/visibility
     if not TargetFrameToT:IsProtected() then
       TargetFrameToT:SetAlpha(1)
+      -- Strip subframes/texture
+      HideSubFrames("TargetFrameToT")
     end
-    -- Strip subframes/texture
-    HideSubFrames("TargetFrameToT")
-    if TargetFrameToTTextureFrame then
+    if TargetFrameToTTextureFrame and not TargetFrameToTTextureFrame:IsProtected() then
       HideTextureRegions(TargetFrameToTTextureFrame)
     end
     -- Always hide auras (regardless of ToT existence)
@@ -196,10 +196,10 @@ local function SetupHooks()
 end
 
 local function InitToTPostSetup()
-  if TargetFrameToT then
+  if TargetFrameToT and not TargetFrameToT:IsProtected() then
       TargetFrameToT:SetAlpha(1)
   end
-  if TargetFrameToTTextureFrame then
+  if TargetFrameToTTextureFrame and not TargetFrameToTTextureFrame:IsProtected() then
       TargetFrameToTTextureFrame:SetAlpha(1)
   end
 end
@@ -209,8 +209,8 @@ local f = CreateFrame("Frame")
 f:RegisterEvent("PLAYER_ENTERING_WORLD")
 f:SetScript("OnEvent", function(self)
     -- Safe because Blizzard has finished secure setup
-    SetupHooks()
     InitToTPostSetup()
+    SetupHooks()
     self:UnregisterEvent("PLAYER_ENTERING_WORLD") -- only needed once
 end)
 

--- a/Functions/SetTargetFrameDisplay.lua
+++ b/Functions/SetTargetFrameDisplay.lua
@@ -27,7 +27,7 @@ local function HideTextureRegions(frame)
 
   for i = 1, select("#", frame:GetRegions()) do
     local region = select(i, frame:GetRegions())
-    if region then
+    if region and not region:IsProtected() then
       region:SetAlpha(0)
     end
   end
@@ -158,9 +158,11 @@ end
 local function ShowToT()
   if not TargetFrameToT then return end
     -- allow Blizzard to show ToT normally
-  TargetFrameToT:SetAlpha(1)
-  if TargetFrameToTTextureFrame then
-    TargetFrameToTTextureFrame:SetAlpha(1)
+  if not InCombatLockdown() then
+    TargetFrameToT:SetAlpha(1)
+    if TargetFrameToTTextureFrame then
+      TargetFrameToTTextureFrame:SetAlpha(1)
+    end
   end
 end
 

--- a/Functions/SetTargetOfTargetFrameDisplay.lua
+++ b/Functions/SetTargetOfTargetFrameDisplay.lua
@@ -133,6 +133,10 @@ local function RestoreUltraToTPosition()
   if GLOBAL_SETTINGS and GLOBAL_SETTINGS.showTargetOfTargetPosition then
     local p = GLOBAL_SETTINGS.showTargetOfTargetPosition
     local rel = _G[p.relativeTo] or UIParent
+    if not p.point then
+      ResetToTPosition()
+      return
+    end
     UltraToTFrame:ClearAllPoints()
     UltraToTFrame:SetPoint(p.point, rel, p.relativePoint, p.x, p.y)
     UltraToTFrame:SetScale(GLOBAL_SETTINGS.showTargetOfTargetScale or 1.0)

--- a/Functions/SetTargetOfTargetFrameDisplay.lua
+++ b/Functions/SetTargetOfTargetFrameDisplay.lua
@@ -1,53 +1,73 @@
--- ============================
+local UltraToTFrame = nil
+
+local function SaveUltraToTPosition()
+  if not UltraToTFrame then return end
+  -- Save position
+  local point, relativeTo, relativePoint, xOfs, yOfs = UltraToTFrame:GetPoint()
+  GLOBAL_SETTINGS.showTargetOfTargetPosition = {
+    point = point,
+    relativeTo = relativeTo and relativeTo:GetName() or "UIParent",
+    relativePoint = relativePoint,
+    x = xOfs,
+    y = yOfs
+  }
+  SaveCharacterSettings(GLOBAL_SETTINGS)
+end
+
 -- Custom ToT Frame (portrait only)
--- ============================
-local UltraToTFrame = CreateFrame("Button", "UltraToTFrame", UIParent, "SecureActionButtonTemplate")
-UltraToTFrame:SetSize(32, 32)
-UltraToTFrame:SetPoint("TOPRIGHT", TargetFrame, "BOTTOM", 20, 22) -- adjust position as desired
+local function CreateUltraToTFrame()
+  UltraToTFrame = CreateFrame("Button", "UltraToTFrame", UIParent, "SecureActionButtonTemplate")
+  UltraToTFrame:SetSize(32, 32)
+  UltraToTFrame:SetPoint("TOPRIGHT", TargetFrame, "BOTTOM", 20, 22) -- adjust position as desired
 
--- Make it clickable to target your target's target
-UltraToTFrame:SetAttribute("type", "target")
-UltraToTFrame:SetAttribute("unit", "targettarget")
+  -- Make it clickable to target your target's target
+  UltraToTFrame:SetAttribute("type", "target")
+  UltraToTFrame:SetAttribute("unit", "targettarget")
 
--- Portrait texture
-UltraToTFrame.Portrait = UltraToTFrame:CreateTexture(nil, "BACKGROUND")
-UltraToTFrame.Portrait:SetAllPoints(UltraToTFrame)
+  -- Portrait texture
+  UltraToTFrame.Portrait = UltraToTFrame:CreateTexture(nil, "BACKGROUND")
+  UltraToTFrame.Portrait:SetAllPoints(UltraToTFrame)
 
--- Make UltraToTFrame movable
-UltraToTFrame:SetMovable(true)
-UltraToTFrame:EnableMouse(true)
-UltraToTFrame:RegisterForDrag("LeftButton")
-UltraToTFrame:SetClampedToScreen(true)
+  -- Make UltraToTFrame movable
+  UltraToTFrame:SetMovable(true)
+  UltraToTFrame:EnableMouse(true)
+  UltraToTFrame:RegisterForDrag("LeftButton")
+  UltraToTFrame:SetClampedToScreen(true)
 
-UltraToTFrame:SetScript("OnDragStart", function(self)
+  UltraToTFrame:SetScript("OnDragStart", function(self)
     if not InCombatLockdown() then
-        self:StartMoving()
+      self:StartMoving()
     end
-end)
+  end)
 
-UltraToTFrame:SetScript("OnDragStop", function(self)
+  UltraToTFrame:SetScript("OnDragStop", function(self)
     if not InCombatLockdown() then
       self:StopMovingOrSizing()
+      SaveUltraToTPosition()
     end
-
-    -- Save position
-    --local point, relativeTo, relativePoint, xOfs, yOfs = self:GetPoint()
-    --UltraToTFrameDB = UltraToTFrameDB or {}
-    --UltraToTFrameDB.point = { point, relativePoint, xOfs, yOfs }
-end)
+  end)
+end
 
 -- Restore position on login
 local function RestoreUltraToTPosition()
-    if UltraToTFrameDB and UltraToTFrameDB.point then
-        local p = UltraToTFrameDB.point
-        UltraToTFrame:ClearAllPoints()
-        UltraToTFrame:SetPoint(p[1], UIParent, p[2], p[3], p[4])
-    end
+  if GLOBAL_SETTINGS and GLOBAL_SETTINGS.showTargetOfTargetPosition then
+    local p = GLOBAL_SETTINGS.showTargetOfTargetPosition
+    local rel = _G[p.relativeTo] or UIParent
+    UltraToTFrame:ClearAllPoints()
+    UltraToTFrame:SetPoint(p.point, rel, p.relativePoint, p.x, p.y)
+    UltraToTFrame:SetScale(GLOBAL_SETTINGS.showTargetOfTargetScale or 1.0)
+  end
 end
 
 
 -- Update portrait visibility
-local function UpdateMyToT()
+local function UpdateUltraToT()
+  if not GLOBAL_SETTINGS.showTargetOfTarget then return end
+  -- If we are hiding the target frame it will look weird 
+  -- if we still show the target of target frame.
+  if GLOBAL_SETTINGS.completelyRemoveTargetFrame then return end
+  if not UltraToTFrame then return end
+
   if UnitExists("targettarget") then
     SetPortraitTexture(UltraToTFrame.Portrait, "targettarget")
     UltraToTFrame:SetAlpha(1)
@@ -56,25 +76,42 @@ local function UpdateMyToT()
   end
 end
 
--- Hide Blizzard's TargetOfTarget Frame
+-- Hide Blizzard ToT Frame since it becomes protected
+-- and we cannot hide the parts we want
 local function HideBlizzardToT()
+  -- A hidden frame we can parent Blizzards ToT to
+  local hiddenFrame = CreateFrame("Frame")
+  hiddenFrame:Hide()
+
   local frame = TargetFrameToT
   if frame then
     UnregisterUnitWatch(frame)
     frame:UnregisterAllEvents()
     frame:Hide()
+    frame:SetParent(hiddenFrame)
   end
 end
 
--- ============================
+-- Reset ToT position function
+local function ResetToTPosition()
+  if not UltraToTFrame then return end
+  -- Clear existing points first
+  UltraToTFrame:ClearAllPoints()
+  -- Set to default position
+  UltraToTFrame:SetPoint("TOPRIGHT", TargetFrame, "BOTTOM", 20, 22) -- adjust position as desired
+  -- Reset scale
+  GLOBAL_SETTINGS.showTargetOfTargetScale = 1
+  UltraToTFrame:SetScale(GLOBAL_SETTINGS.showTargetOfTargetScale)
+  SaveUltraToTPosition()
+end
+
 -- Event handler
--- ============================
 local f = CreateFrame("Frame")
 f:RegisterEvent("PLAYER_ENTERING_WORLD")
 f:RegisterEvent("ZONE_CHANGED_NEW_AREA")
 f:RegisterEvent("PLAYER_TARGET_CHANGED")
 f:RegisterEvent("UNIT_TARGET")
-f:SetScript("OnEvent", UpdateMyToT)
+f:SetScript("OnEvent", UpdateUltraToT)
 
 local initFrame = CreateFrame("Frame")
 initFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
@@ -82,7 +119,19 @@ initFrame:SetScript("OnEvent", function()
   -- Initial run (for first login)
   C_Timer.After(0.5, function()
     HideBlizzardToT()
-    UpdateMyToT()
+    CreateUltraToTFrame()
+    RestoreUltraToTPosition()
+    UpdateUltraToT()
   end)
   initFrame:UnregisterEvent("PLAYER_ENTERING_WORLD")
 end)
+
+-- Slash command to reset ToT position
+-- TODO  move all our slash commands to a common file under the /ultra prefix
+SLASH_ULTRA1 = "/ultra"
+SlashCmdList["ULTRA"] = function(msg)
+  if msg == "reset tot" then
+    print("ULTRA ToT position reset")
+    ResetToTPosition()
+  end
+end

--- a/Functions/SetTargetOfTargetFrameDisplay.lua
+++ b/Functions/SetTargetOfTargetFrameDisplay.lua
@@ -1,0 +1,88 @@
+-- ============================
+-- Custom ToT Frame (portrait only)
+-- ============================
+local UltraToTFrame = CreateFrame("Button", "UltraToTFrame", UIParent, "SecureActionButtonTemplate")
+UltraToTFrame:SetSize(32, 32)
+UltraToTFrame:SetPoint("TOPRIGHT", TargetFrame, "BOTTOM", 20, 22) -- adjust position as desired
+
+-- Make it clickable to target your target's target
+UltraToTFrame:SetAttribute("type", "target")
+UltraToTFrame:SetAttribute("unit", "targettarget")
+
+-- Portrait texture
+UltraToTFrame.Portrait = UltraToTFrame:CreateTexture(nil, "BACKGROUND")
+UltraToTFrame.Portrait:SetAllPoints(UltraToTFrame)
+
+-- Make UltraToTFrame movable
+UltraToTFrame:SetMovable(true)
+UltraToTFrame:EnableMouse(true)
+UltraToTFrame:RegisterForDrag("LeftButton")
+UltraToTFrame:SetClampedToScreen(true)
+
+UltraToTFrame:SetScript("OnDragStart", function(self)
+    if not InCombatLockdown() then
+        self:StartMoving()
+    end
+end)
+
+UltraToTFrame:SetScript("OnDragStop", function(self)
+    if not InCombatLockdown() then
+      self:StopMovingOrSizing()
+    end
+
+    -- Save position
+    --local point, relativeTo, relativePoint, xOfs, yOfs = self:GetPoint()
+    --UltraToTFrameDB = UltraToTFrameDB or {}
+    --UltraToTFrameDB.point = { point, relativePoint, xOfs, yOfs }
+end)
+
+-- Restore position on login
+local function RestoreUltraToTPosition()
+    if UltraToTFrameDB and UltraToTFrameDB.point then
+        local p = UltraToTFrameDB.point
+        UltraToTFrame:ClearAllPoints()
+        UltraToTFrame:SetPoint(p[1], UIParent, p[2], p[3], p[4])
+    end
+end
+
+
+-- Update portrait visibility
+local function UpdateMyToT()
+  if UnitExists("targettarget") then
+    SetPortraitTexture(UltraToTFrame.Portrait, "targettarget")
+    UltraToTFrame:SetAlpha(1)
+  else
+    UltraToTFrame:SetAlpha(0)
+  end
+end
+
+-- Hide Blizzard's TargetOfTarget Frame
+local function HideBlizzardToT()
+  local frame = TargetFrameToT
+  if frame then
+    UnregisterUnitWatch(frame)
+    frame:UnregisterAllEvents()
+    frame:Hide()
+  end
+end
+
+-- ============================
+-- Event handler
+-- ============================
+local f = CreateFrame("Frame")
+f:RegisterEvent("PLAYER_ENTERING_WORLD")
+f:RegisterEvent("ZONE_CHANGED_NEW_AREA")
+f:RegisterEvent("PLAYER_TARGET_CHANGED")
+f:RegisterEvent("UNIT_TARGET")
+f:SetScript("OnEvent", UpdateMyToT)
+
+local initFrame = CreateFrame("Frame")
+initFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
+initFrame:SetScript("OnEvent", function()
+  -- Initial run (for first login)
+  C_Timer.After(0.5, function()
+    HideBlizzardToT()
+    UpdateMyToT()
+  end)
+  initFrame:UnregisterEvent("PLAYER_ENTERING_WORLD")
+end)

--- a/Settings/CommandsTab.lua
+++ b/Settings/CommandsTab.lua
@@ -135,6 +135,8 @@ function InitializeCommandsTab()
       { '/resetclockposition, /rcp', 'Reset the minimap clock to the default position.' },
       { '/resetmailposition, /rmp', 'Reset the minimap mail icon to the default position.' },
       { '/resetresourcebar, /rrb', 'Reset the custom resource bar to its default position.' },
+      { '/ultra reset tot', 'Reset the Target of Target frame to its default position.' },
+
     },
   } }
 

--- a/Settings/SettingsOptionsTab.lua
+++ b/Settings/SettingsOptionsTab.lua
@@ -91,6 +91,10 @@ local settingsCheckboxOptions = { {
   dbSettingsValueName = 'completelyRemoveTargetFrame',
   tooltip = 'Completely remove the target frame',
 }, {
+  name = 'Show Target of Target Frame',
+  dbSettingsValueName = 'showTargetOfTarget',
+  tooltip = 'Shows a Target of Target portrait only frame',
+}, {
   name = 'Show Target Buffs',
   dbSettingsValueName = 'showTargetBuffs',
   tooltip = 'Show buffs on the target frame',
@@ -1692,13 +1696,13 @@ function InitializeSettingsOptionsTab()
 
   addUIRow(opacityRow, 'statistics background opacity transparency', statsSubHeader)
 
-  -- Minimap Clock Scale subheader
-  local clockSubHeader = colorSectionFrame:CreateFontString(nil, 'OVERLAY', SUBHEADER_FONT)
+  -- Scale subheader
+  local scaleSubHeader = colorSectionFrame:CreateFontString(nil, 'OVERLAY', SUBHEADER_FONT)
   -- Position will be handled by reflow
-  clockSubHeader:SetPoint('TOPLEFT', opacityRow, 'BOTTOMLEFT', -14, -12)
-  clockSubHeader:SetText('Minimap Clock Scale')
-  clockSubHeader:SetTextColor(0.922, 0.871, 0.761)
-  addUIHeader(clockSubHeader)
+  scaleSubHeader:SetPoint('TOPLEFT', opacityRow, 'BOTTOMLEFT', -14, -12)
+  scaleSubHeader:SetText('Scaling')
+  scaleSubHeader:SetTextColor(0.922, 0.871, 0.761)
+  addUIHeader(scaleSubHeader)
 
   local minimapClockScaleRow = CreateFrame('Frame', nil, colorSectionFrame)
   minimapClockScaleRow:SetSize(LAYOUT.ROW_WIDTH, LAYOUT.COLOR_ROW_HEIGHT) -- Increased width to match new layout
@@ -1713,7 +1717,7 @@ function InitializeSettingsOptionsTab()
   minimapClockScaleLabel:SetPoint('LEFT', minimapClockScaleRow, 'LEFT', 0, 0)
   minimapClockScaleLabel:SetWidth(LABEL_WIDTH2)
   minimapClockScaleLabel:SetJustifyH('LEFT')
-  minimapClockScaleLabel:SetText('Minimap Clock Scale')
+  minimapClockScaleLabel:SetText('Clock Scale')
 
   if tempSettings.minimapClockScale == nil then
     tempSettings.minimapClockScale = GLOBAL_SETTINGS.minimapClockScale or 1.0
@@ -1759,15 +1763,8 @@ function InitializeSettingsOptionsTab()
   end)
   addUIRow(minimapClockScaleRow, 'minimap clock scale size', clockSubHeader)
 
-  -- Minimap mail Scale subheader
-  local mailSubHeader = colorSectionFrame:CreateFontString(nil, 'OVERLAY', SUBHEADER_FONT)
-  -- Position will be handled by reflow
-  mailSubHeader:SetPoint('TOPLEFT', minimapClockScaleRow, 'BOTTOMLEFT', -14, -12)
-  mailSubHeader:SetText('Minimap Mail Scale')
-  mailSubHeader:SetTextColor(0.922, 0.871, 0.761)
-  addUIHeader(mailSubHeader)
 
-  local minimapMailScaleRow = CreateFrame('Frame', nil, minimapClockScaleRow)
+  local minimapMailScaleRow = CreateFrame('Frame', nil, minimapClockScaleSlider)
   minimapMailScaleRow:SetSize(LAYOUT.ROW_WIDTH, LAYOUT.COLOR_ROW_HEIGHT) -- Increased width to match new layout
   -- Position will be handled by reflow
   minimapMailScaleRow:SetPoint('TOPLEFT', mailSubHeader, 'BOTTOMLEFT', 14, -6)
@@ -1777,7 +1774,7 @@ function InitializeSettingsOptionsTab()
   minimapMailScaleLabel:SetPoint('LEFT', minimapMailScaleRow, 'LEFT', 0, 0)
   minimapMailScaleLabel:SetWidth(LABEL_WIDTH2)
   minimapMailScaleLabel:SetJustifyH('LEFT')
-  minimapMailScaleLabel:SetText('Minimap Mail Scale')
+  minimapMailScaleLabel:SetText('Mail Indicator Scale')
 
   if tempSettings.minimapMailScale == nil then
     tempSettings.minimapMailScale = GLOBAL_SETTINGS.minimapMailScale or 1.0
@@ -1816,6 +1813,56 @@ function InitializeSettingsOptionsTab()
     tempSettings.minimapMailScale = steps / 10
   end)
   addUIRow(minimapMailScaleRow, 'minimap mail scale size', mailSubHeader)
+
+  local ultraToTScaleRow = CreateFrame('Frame', nil, minimapMailScaleSlider)
+  ultraToTScaleRow:SetSize(LAYOUT.ROW_WIDTH, LAYOUT.COLOR_ROW_HEIGHT) -- Increased width to match new layout
+  -- Position will be handled by reflow
+  ultraToTScaleRow:SetPoint('TOPLEFT', mailSubHeader, 'BOTTOMLEFT', 14, -6)
+
+  local ultraToTScaleLabel =
+    ultraToTScaleRow:CreateFontString(nil, 'OVERLAY', 'GameFontHighlight')
+  ultraToTScaleLabel:SetPoint('LEFT', ultraToTScaleRow, 'LEFT', 0, 0)
+  ultraToTScaleLabel:SetWidth(LABEL_WIDTH2)
+  ultraToTScaleLabel:SetJustifyH('LEFT')
+  ultraToTScaleLabel:SetText('Target of Target Scale')
+
+  if tempSettings.showTargetOfTargetScale == nil then
+    tempSettings.showTargetOfTargetScale = GLOBAL_SETTINGS.showTargetOfTargetScale or 1.0
+  end
+
+  local ultraToTScalePercent =
+    ultraToTScaleRow:CreateFontString(nil, 'OVERLAY', 'GameFontHighlight')
+  ultraToTScalePercent:SetPoint('LEFT', ultraToTScaleRow, 'LEFT', LABEL_WIDTH2 + GAP2, 0)
+  ultraToTScalePercent:SetWidth(40)
+  ultraToTScalePercent:SetJustifyH('LEFT')
+  ultraToTScalePercent:SetText(
+    tostring(math.floor((tempSettings.showTargetOfTargetScale or 1.0) * 100)) .. '%'
+  )
+
+  local ultraToTScaleSlider =
+    CreateFrame('Slider', nil, ultraToTScaleRow, 'OptionsSliderTemplate')
+  ultraToTScaleSlider:SetPoint('LEFT', ultraToTScalePercent, 'RIGHT', 10, 0)
+  ultraToTScaleSlider:SetSize(180, 16)
+  ultraToTScaleSlider:SetMinMaxValues(10, 20)
+  ultraToTScaleSlider:SetValueStep(1)
+  ultraToTScaleSlider:SetObeyStepOnDrag(true)
+  ultraToTScaleSlider:SetValue(math.floor(((tempSettings.showTargetOfTargetScale or 1.0) * 10) + 0.5))
+  if ultraToTScaleSlider.Low then
+    ultraToTScaleSlider.Low:SetText('100%')
+  end
+  if ultraToTScaleSlider.High then
+    ultraToTScaleSlider.High:SetText('200%')
+  end
+  if ultraToTScaleSlider.Text then
+    ultraToTScaleSlider.Text:SetText('')
+  end
+
+  ultraToTScaleSlider:SetScript('OnValueChanged', function(self, val)
+    local steps = math.floor(val + 0.5)
+    ultraToTScalePercent:SetText((steps * 10) .. '%')
+    tempSettings.showTargetOfTargetScale = steps / 10
+  end)
+  addUIRow(ultraToTScaleRow, 'Target of Target scale size', minimapMailScaleRow)
 
   -- Dynamic Reflow Function
   -- Stacks visible UI elements vertically. When searching, headers only appear if their children match.

--- a/UltraHardcore.toc
+++ b/UltraHardcore.toc
@@ -20,6 +20,7 @@ Functions/PlayerComm.lua
 Functions/SetPlayerFrameDisplay.lua
 Functions/SetMinimapDisplay.lua
 Functions/SetTargetFrameDisplay.lua
+Functions/SetTargetOfTargetFrameDisplay.lua
 Functions/SetTargetTooltipDisplay.lua
 Functions/SetUIErrorsDisplay.lua
 Functions/TunnelVision.lua


### PR DESCRIPTION
### Summary

- Hiding Blizzard's Target of Target frame and leaving it untouched to avoid protection errors.
- Added new UltraToT frame
- Added an option to turn on Target of Target
- Added position and scaling to ToT frame
- Put all scaling sliders under a single Scaling header instead of a header for each slider
- Moved all ToT code to its own file instead of having it in PlayerFrame and TargetFrame files.
- Added context menu to ToT frame to lock/unlock or reset position
- Added a command-line switch to restore the target of target position.  
- TODO: Move all our commands under a /ultra command

### Testing Steps (in-game)

1. Turn on Show Target of Target Frame in the ULTRA settings (no need to have Blizzard's target of target option on, but it shouldn't matter if you do, since we hide it.
2. Target and attack something.  You should see a ToT frame.
3. Zone into an instance and repeat and verify no Protected function errors about TargetFrameToT:Show() or Hide()
