### PR TITLE
Enable tracking button when resource map is always on. Cleanup minimap hide functions and dependency cascading.

### DIFF
--- a/Constants/PresetSections.lua
+++ b/Constants/PresetSections.lua
@@ -46,7 +46,6 @@ local PRESET_SECTIONS = { {
   settings = {
     'alwaysShowResourceMap',
     'showPlayerArrowOnResourceMap',
-    'showTrackingButtonEvenWhenMapHidden',
   },
 }, {
   title = 'Misc:',
@@ -58,6 +57,7 @@ local PRESET_SECTIONS = { {
     'hideUIErrors',
     'showClockEvenWhenMapHidden',
     'showMailEvenWhenMapHidden',
+    'showTrackingWhenMapHidden',
     'announcePartyDeathsOnGroupJoin',
     'announceDungeonsCompletedOnGroupJoin',
     'buffBarOnResourceBar',

--- a/Constants/PresetSections.lua
+++ b/Constants/PresetSections.lua
@@ -46,6 +46,7 @@ local PRESET_SECTIONS = { {
   settings = {
     'alwaysShowResourceMap',
     'showPlayerArrowOnResourceMap',
+    'showTrackingButtonEvenWhenMapHidden',
   },
 }, {
   title = 'Misc:',

--- a/Functions/SetMinimapDisplay.lua
+++ b/Functions/SetMinimapDisplay.lua
@@ -156,7 +156,6 @@ local function DisableMouseAndHideChildren(f)
     if child.EnableMouse then child:EnableMouse(false) end
     if child.EnableMouseWheel then child:EnableMouseWheel(false) end
     if child and child:IsShown() then
-      -- Uncomment to debug which children are being hidden
       child:Hide()
     end
   end
@@ -264,9 +263,7 @@ function HideMinimap()
       Minimap:SetPlayerTexture("")
     end
 
-    C_Timer.After(3, function()
-      RevealMinimapForTracking(isAlwaysOn)
-    end)
+    RevealMinimapForTracking(isAlwaysOn)
   else
     -- Standard hide mode
     Minimap:SetBlipTexture("Interface\\AddOns\\UltraHardcore\\Textures\\ObjectIconsAtlasRestricted.png")
@@ -344,15 +341,7 @@ function RevealMinimapForTracking(isAlwaysOn)
     Minimap:SetScale(8.0)
   end
 
-  -- Only hide child frames for temporary reveal (not Always On mode)
-  -- This prevents addon buttons (like MinimapButtonButton) from being hidden permanently
-  if isAlwaysOn then
-    minimapCleanupTicker = C_Timer.NewTicker(5, function()
-      DisableMouseAndHideChildren(Minimap)
-    end)
-  else
-    DisableMouseAndHideChildren(Minimap)
-  end
+  DisableMouseAndHideChildren(Minimap)
 
   -- Hide extra minimap adornments while revealing
   minimapRevealState.toggledFrames = {}
@@ -364,9 +353,10 @@ function RevealMinimapForTracking(isAlwaysOn)
     end
   end
 
-  hideTemp(_G.MiniMapTracking)
+  -- TODO: Delete these, they don't seem to actually do anything
+  -- hideTemp(_G.MiniMapTracking)
   hideTemp(_G.GameTimeFrame)
-  hideTemp(_G.MiniMapMailFrame)
+  -- hideTemp(_G.MiniMapMailFrame)
   hideTemp(_G.MinimapBorder)
   hideTemp(_G.MinimapBackdrop)
   hideTemp(_G.MinimapBorderTop)
@@ -490,6 +480,25 @@ local function ResetMailPosition()
   print('UltraHardcore: Mail position reset to default')
 end
 
+-- Reset tracking position function
+local function ResetTrackingPosition()
+  if not MiniMapTracking then
+    print("MiniMapTracking not found!")
+    return
+  end
+
+  -- Clear existing points first
+  MiniMapTracking:ClearAllPoints()
+  -- Reset to default position (top right)
+  MiniMapTracking:SetPoint('TOPRIGHT', UIParent, 'TOPRIGHT', -20, -50)
+
+  -- Save the reset position
+  local point, _, relPoint, x, y = MiniMapTracking:GetPoint()
+  UltraHardcoreDB.MiniMapTrackingPosition = { point = point, relPoint = relPoint, x = x, y = y }
+  SaveDBData('MiniMapTrackingPosition', UltraHardcoreDB.MiniMapTrackingPosition)
+  print('UltraHardcore: Tracking position reset to default')
+end
+
 -- Slash command to reset clock position
 SLASH_RESETCLOCKPOSITION1 = '/resetclockposition'
 SLASH_RESETCLOCKPOSITION2 = '/rcp'
@@ -499,3 +508,8 @@ SlashCmdList['RESETCLOCKPOSITION'] = ResetClockPosition
 SLASH_RESETMAILPOSITION1 = '/resetmailposition'
 SLASH_RESETMAILPOSITION2 = '/rmp'
 SlashCmdList['RESETMAILPOSITION'] = ResetMailPosition
+
+-- Slash command to reset tracking position
+SLASH_RESETTRACKINGPOSITION1 = '/resettrackingposition'
+SLASH_RESETTRACKINGPOSITION2 = '/rtp'
+SlashCmdList['RESETTRACKINGPOSITION'] = ResetTrackingPosition

--- a/Functions/SetMinimapDisplay.lua
+++ b/Functions/SetMinimapDisplay.lua
@@ -1,4 +1,5 @@
 local minimapHideTimer = nil
+local minimapCleanupTicker = nil
 local initialRotateMinimap = GetCVar("RotateMinimap") or false
 
 -- Track temporary reveal state so we can restore cleanly on any event
@@ -20,6 +21,10 @@ local function ResetMinimapRevealState()
   if minimapHideTimer then
     minimapHideTimer:Cancel()
     minimapHideTimer = nil
+  end
+  if minimapCleanupTicker then
+    minimapCleanupTicker:Cancel()
+    minimapCleanupTicker = nil
   end
   if not minimapRevealState.active then return end
 
@@ -132,9 +137,13 @@ end
 -- Take the given frame and disable the mouse and hide for all children
 local function DisableMouseAndHideChildren(f)
   for _, child in ipairs({ f:GetChildren() }) do
-    if child and child.EnableMouse then child:EnableMouse(false) end
-    if child and child.EnableMouseWheel then child:EnableMouseWheel(false) end
-    if child then child:Hide() end
+    if child.EnableMouse then child:EnableMouse(false) end
+    if child.EnableMouseWheel then child:EnableMouseWheel(false) end
+    if child and child:IsShown() then
+      -- Uncomment to debug which children are being hidden
+      -- print("UltraHardcore: Hiding child:", child:GetName())
+      child:Hide()
+    end
   end
 end
 
@@ -196,168 +205,178 @@ function HideMinimap()
   -- Ensure no temporary reveal leftovers are active
   ResetMinimapRevealState()
 
-  -- Set blip texture based on Always On mode
-  if GLOBAL_SETTINGS and GLOBAL_SETTINGS.alwaysShowResourceMap then
-    Minimap:SetBlipTexture("Interface\\AddOns\\UltraHardcore\\Textures\\ObjectIconsAtlasRestricted-AlwaysOn.png")
-    -- Show player arrow if setting is enabled
-    if GLOBAL_SETTINGS.showPlayerArrowOnResourceMap then
-      Minimap:SetPlayerTexture("Interface\\Minimap\\MinimapArrow")
-    else
-      Minimap:SetPlayerTexture("")
-    end
-  else
-    -- Standard hide mode
-    Minimap:SetBlipTexture("Interface\\AddOns\\UltraHardcore\\Textures\\ObjectIconsAtlasRestricted.png")
-    Minimap:SetPlayerTexture("")
-  end
-
   -- Make the minimap invisible by default
   Minimap:SetAlpha(0)
   Minimap:Hide()
   MinimapCluster:Hide()
 
-  -- Register spell event handler
-  Minimap:RegisterEvent('UNIT_SPELLCAST_SUCCEEDED')
-  Minimap:SetScript("OnEvent", function(self, event, ...)
-    local unit, _, spellId = ...
-    local initialZoom = Minimap:GetZoom()
+  -- Just check settings for specific toggles once
+  local isAlwaysOn = GLOBAL_SETTINGS and GLOBAL_SETTINGS.alwaysShowResourceMap
+  local showPlayerArrow = GLOBAL_SETTINGS and GLOBAL_SETTINGS.showPlayerArrowOnResourceMap
 
-    -- Tracking spells that should trigger the resource map reveal
-    local trackingSpellIDs = {
-      [2580] = true, -- Find Minerals
-      [2383] = true, -- Find Herbs
-      [2481] = true, -- Find Treasure
-      [1494] = true, -- Track Beasts
-      [19880] = true, -- Track Elementals
-      [19882] = true, -- Track Giants
-      [19883] = true, -- Track Humanoids (Hunter)
-      [5225] = true, -- Track Humanoids (Druid)
-      [19884] = true, -- Track Undead
-      [19878] = true, -- Track Demons
-      [19879] = true, -- Track Dragonkin
-      [19885] = true, -- Track Hidden
-      [5502] = true, -- Sense Undead
-      [5500] = true, -- Sense Demons
-      [10242] = true, -- Elemental Tracking
-      [5124] = true, -- Elemental Tracker
-    }
+  -- Set blip texture based on Always On mode
+  if isAlwaysOn then
+    Minimap:SetBlipTexture("Interface\\AddOns\\UltraHardcore\\Textures\\ObjectIconsAtlasRestricted-AlwaysOn.png")
+    -- Show player arrow if setting is enabled
+    if showPlayerArrow then
+      Minimap:SetPlayerTexture("Interface\\Minimap\\MinimapArrow")
+    else
+      Minimap:SetPlayerTexture("")
+    end
 
-    local isAlwaysOn = GLOBAL_SETTINGS and GLOBAL_SETTINGS.alwaysShowResourceMap
+    C_Timer.After(3, function()
+      RevealMinimapForTracking(isAlwaysOn)
+    end)
+  else
+    -- Standard hide mode
+    Minimap:SetBlipTexture("Interface\\AddOns\\UltraHardcore\\Textures\\ObjectIconsAtlasRestricted.png")
+    Minimap:SetPlayerTexture("")
 
-    if (unit == 'player' and trackingSpellIDs[spellId]) or isAlwaysOn then
-      -- Reset any existing reveal state to ensure we capture the true 'base' state
-      ResetMinimapRevealState()
+    -- Register spell event handler
+    Minimap:RegisterEvent('UNIT_SPELLCAST_SUCCEEDED')
+    Minimap:SetScript("OnEvent", function(self, event, ...)
+      local unit, _, spellId = ...
+      local initialZoom = Minimap:GetZoom()
 
-      -- Temporarily make the minimap rotate with the user
-      SetCVar("RotateMinimap", true)
+      -- Tracking spells that should trigger the resource map reveal
+      local trackingSpellIDs = {
+        [2580] = true, -- Find Minerals
+        [2383] = true, -- Find Herbs
+        [2481] = true, -- Find Treasure
+        [1494] = true, -- Track Beasts
+        [19880] = true, -- Track Elementals
+        [19882] = true, -- Track Giants
+        [19883] = true, -- Track Humanoids (Hunter)
+        [5225] = true, -- Track Humanoids (Druid)
+        [19884] = true, -- Track Undead
+        [19878] = true, -- Track Demons
+        [19879] = true, -- Track Dragonkin
+        [19885] = true, -- Track Hidden
+        [5502] = true, -- Sense Undead
+        [5500] = true, -- Sense Demons
+        [10242] = true, -- Elemental Tracking
+        [5124] = true, -- Elemental Tracker
+      }
 
-      -- Allow clicks through minimap while this is up
-      Minimap:EnableMouse(false)
-      -- Prevent zooming when showing our tracking
-      Minimap:EnableMouseWheel(false)
-
-      -- Capture original state so we can restore it cleanly
-      minimapRevealState.active = true
-      minimapRevealState.originalParent = Minimap:GetParent()
-      local originalPoint, _, originalRelPoint, originalX, originalY = Minimap:GetPoint(1)
-      minimapRevealState.originalPoint = originalPoint
-      minimapRevealState.originalRelPoint = originalRelPoint
-      minimapRevealState.originalX = originalX
-      minimapRevealState.originalY = originalY
-      minimapRevealState.originalScale = Minimap:GetScale()
-      minimapRevealState.originalAlpha = Minimap:GetAlpha()
-      minimapRevealState.initialZoom = initialZoom
-
-      -- Detach the minimap from its cluster so we can show ONLY the map
-      Minimap:SetParent(UIParent)
-
-      Minimap:ClearAllPoints()
-
-      if isAlwaysOn then
-        -- Normal position/scale for Always On mode
-        Minimap:SetPoint("TOPRIGHT", UIParent, "TOPRIGHT", -20, -20)
-        Minimap:SetScale(1.0)
-      else
-        -- Giant/Center for standard reveal
-        Minimap:SetPoint("CENTER", UIParent, "CENTER", 0, 0)
-        Minimap:SetScale(8.0)
+      if (unit == 'player' and trackingSpellIDs[spellId]) then
+        RevealMinimapForTracking(isAlwaysOn)
       end
+    end)
+  end
+end
 
-      -- Only hide child frames for temporary reveal (not Always On mode)
-      -- This prevents addon buttons (like MinimapButtonButton) from being hidden permanently
-      if not isAlwaysOn then
-        DisableMouseAndHideChildren(Minimap)
-      end
+function RevealMinimapForTracking(isAlwaysOn)
+  if isAlwaysOn then
+    print("UltraHardcore: Minimap reveal triggered - Always On mode")
+  else
+    print("UltraHardcore: Minimap reveal triggered - Standard mode")
+  end
 
-      -- Hide extra minimap adornments while revealing
-      minimapRevealState.toggledFrames = {}
-      minimapRevealState.toggledRegions = {}
-      local function hideTemp(frame)
-        if frame and frame.Hide then
-          table.insert(minimapRevealState.toggledFrames, { frame = frame, wasShown = frame:IsShown() })
-          frame:Hide()
+  -- Reset any existing reveal state to ensure we capture the true 'base' state
+  ResetMinimapRevealState()
+
+  -- Temporarily make the minimap rotate with the user
+  SetCVar("RotateMinimap", true)
+
+  -- Allow clicks through minimap while this is up
+  Minimap:EnableMouse(false)
+  -- Prevent zooming when showing our tracking
+  Minimap:EnableMouseWheel(false)
+
+  -- Capture original state so we can restore it cleanly
+  minimapRevealState.active = true
+  minimapRevealState.originalParent = Minimap:GetParent()
+  local originalPoint, _, originalRelPoint, originalX, originalY = Minimap:GetPoint(1)
+  minimapRevealState.originalPoint = originalPoint
+  minimapRevealState.originalRelPoint = originalRelPoint
+  minimapRevealState.originalX = originalX
+  minimapRevealState.originalY = originalY
+  minimapRevealState.originalScale = Minimap:GetScale()
+  minimapRevealState.originalAlpha = Minimap:GetAlpha()
+  minimapRevealState.initialZoom = initialZoom
+
+  -- Detach the minimap from its cluster so we can show ONLY the map
+  Minimap:SetParent(UIParent)
+
+  Minimap:ClearAllPoints()
+
+  if isAlwaysOn then
+    -- Normal position/scale for Always On mode
+    Minimap:SetPoint("TOPRIGHT", UIParent, "TOPRIGHT", -20, -20)
+    Minimap:SetScale(1.0)
+  else
+    -- Giant/Center for standard reveal
+    Minimap:SetPoint("CENTER", UIParent, "CENTER", 0, 0)
+    Minimap:SetScale(8.0)
+  end
+
+  -- Only hide child frames for temporary reveal (not Always On mode)
+  -- This prevents addon buttons (like MinimapButtonButton) from being hidden permanently
+  if isAlwaysOn then
+    DisableMouseAndHideChildren(Minimap)
+    minimapCleanupTicker = C_Timer.NewTicker(5, function()
+      DisableMouseAndHideChildren(Minimap)
+    end)
+  else
+    DisableMouseAndHideChildren(Minimap)
+  end
+
+  -- Hide extra minimap adornments while revealing
+  minimapRevealState.toggledFrames = {}
+  minimapRevealState.toggledRegions = {}
+  local function hideTemp(frame)
+    if frame and frame.Hide then
+      table.insert(minimapRevealState.toggledFrames, { frame = frame, wasShown = frame:IsShown() })
+      frame:Hide()
+    end
+  end
+
+  hideTemp(_G.MiniMapTracking)
+  hideTemp(_G.GameTimeFrame)
+  hideTemp(_G.MiniMapMailFrame)
+  hideTemp(_G.MinimapBorder)
+  hideTemp(_G.MinimapBackdrop)
+  hideTemp(_G.MinimapBorderTop)
+  hideTemp(_G.MinimapZoomIn)
+  hideTemp(_G.MinimapZoomOut)
+  hideTemp(_G.MinimapCompassTexture)
+  hideTemp(_G.MinimapNorthTag)
+
+  -- Hide terrain/background and border texture regions so only blips remain
+  do
+    local regions = { Minimap:GetRegions() }
+    for _, region in ipairs(regions) do
+      if region and region.GetObjectType and region:GetObjectType() == "Texture" then
+        local layer = (region.GetDrawLayer and region:GetDrawLayer()) or nil
+        -- Hide all terrain/background/border art so only blips remain
+        if layer == "BACKGROUND" or layer == "BORDER" or layer == "ARTWORK" then
+          table.insert(minimapRevealState.toggledRegions, { region = region, wasShown = region:IsShown() })
+          region:Hide()
         end
-      end
-
-      hideTemp(_G.MiniMapTracking)
-      hideTemp(_G.GameTimeFrame)
-      hideTemp(_G.MiniMapMailFrame)
-      hideTemp(_G.MinimapBorder)
-      hideTemp(_G.MinimapBackdrop)
-      hideTemp(_G.MinimapBorderTop)
-      hideTemp(_G.MinimapZoomIn)
-      hideTemp(_G.MinimapZoomOut)
-      hideTemp(_G.MinimapCompassTexture)
-      hideTemp(_G.MinimapNorthTag)
-
-      -- Hide terrain/background and border texture regions so only blips remain
-      do
-        local regions = { Minimap:GetRegions() }
-        for _, region in ipairs(regions) do
-          if region and region.GetObjectType and region:GetObjectType() == "Texture" then
-            local layer = (region.GetDrawLayer and region:GetDrawLayer()) or nil
-            -- Hide all terrain/background/border art so only blips remain
-            if layer == "BACKGROUND" or layer == "BORDER" or layer == "ARTWORK" then
-              table.insert(minimapRevealState.toggledRegions, { region = region, wasShown = region:IsShown() })
-              region:Hide()
-            end
-          end
-        end
-      end
-
-      -- Show only the minimap (keep cluster elements hidden)
-      Minimap:Show()
-      Minimap:SetZoom(0)
-
-      -- Cancel any existing 'hide' timer
-      if minimapHideTimer then
-        minimapHideTimer:Cancel()
-      end
-
-      -- Only set timer if NOT in Always On mode
-      if not isAlwaysOn then
-        -- After a few seconds, hide the minimap again
-        minimapHideTimer = C_Timer.NewTimer(5, function()
-          -- Restore any temporary reveal state
-          ResetMinimapRevealState()
-          -- Then ensure minimap stays hidden if the setting is enabled
-          if GLOBAL_SETTINGS and GLOBAL_SETTINGS.hideMinimap then
-            Minimap:Hide()
-            MinimapCluster:Hide()
-            Minimap:SetAlpha(0)
-          end
-        end)
       end
     end
-  end)
+  end
 
-  -- If Always On mode is enabled, manually trigger the reveal immediately
-  if GLOBAL_SETTINGS and GLOBAL_SETTINGS.alwaysShowResourceMap then
-    C_Timer.After(0.1, function()
-      local handler = Minimap:GetScript("OnEvent")
-      if handler then
-        -- Trigger with a fake spell ID (use Find Herbs as trigger)
-        handler(Minimap, "UNIT_SPELLCAST_SUCCEEDED", "player", "", 2383)
+  -- Show only the minimap (keep cluster elements hidden)
+  Minimap:Show()
+  Minimap:SetZoom(0)
+
+  -- Cancel any existing 'hide' timer
+  if minimapHideTimer then
+    minimapHideTimer:Cancel()
+  end
+
+  -- Only set timer if NOT in Always On mode
+  if not isAlwaysOn then
+    -- After a few seconds, hide the minimap again
+    minimapHideTimer = C_Timer.NewTimer(5, function()
+      -- Restore any temporary reveal state
+      ResetMinimapRevealState()
+      -- Then ensure minimap stays hidden if the setting is enabled
+      if GLOBAL_SETTINGS and GLOBAL_SETTINGS.hideMinimap then
+        Minimap:Hide()
+        MinimapCluster:Hide()
+        Minimap:SetAlpha(0)
       end
     end)
   end

--- a/Functions/SetMinimapDisplay.lua
+++ b/Functions/SetMinimapDisplay.lua
@@ -339,9 +339,11 @@ function RevealMinimapForTracking(isAlwaysOn)
     -- Giant/Center for standard reveal
     Minimap:SetPoint("CENTER", UIParent, "CENTER", 0, 0)
     Minimap:SetScale(8.0)
+
+    DisableMouseAndHideChildren(Minimap)
   end
 
-  DisableMouseAndHideChildren(Minimap)
+  
 
   -- Hide extra minimap adornments while revealing
   minimapRevealState.toggledFrames = {}

--- a/Settings/CommandsTab.lua
+++ b/Settings/CommandsTab.lua
@@ -129,6 +129,7 @@ function InitializeCommandsTab()
     items = {
       { '/resetclockposition, /rcp', 'Reset the minimap clock to the default position.' },
       { '/resetmailposition, /rmp', 'Reset the minimap mail icon to the default position.' },
+      { '/resettrackingposition, /rtp', 'Reset the minimap tracking button to the default position.' },
       { '/resetresourcebar, /rrb', 'Reset the custom resource bar to its default position.' },
       { '/ultra reset tot', 'Reset the Target of Target frame to its default position.' },
 

--- a/Settings/SettingsOptionsTab.lua
+++ b/Settings/SettingsOptionsTab.lua
@@ -131,10 +131,12 @@ local settingsCheckboxOptions = { {
   name = 'Show Clock When Minimap is Hidden',
   dbSettingsValueName = 'showClockEvenWhenMapHidden',
   tooltip = 'If Hide Minimap is enabled, keep the clock on display instead of hiding it',
+  dependsOn = 'hideMinimap',
 }, {
   name = 'Show Mail Indicator When Minimap is Hidden',
   dbSettingsValueName = 'showMailEvenWhenMapHidden',
   tooltip = 'If Hide Minimap is enabled, keep the mail indicator on display instead of hiding it',
+  dependsOn = 'hideMinimap',
 }, {
   name = 'Announce Party Deaths on Group Join',
   dbSettingsValueName = 'announcePartyDeathsOnGroupJoin',
@@ -207,8 +209,8 @@ local settingsCheckboxOptions = { {
   dependsOn = 'alwaysShowResourceMap',
 }, {
   name = 'Show Tracking Button When Minimap is Hidden',
-  dbSettingsValueName = 'showTrackingButtonEvenWhenMapHidden',
-  tooltip = 'If Hide Minimap is enabled, keep the tracking button on display instead of hiding it',
+  dbSettingsValueName = 'showTrackingWhenMapHidden',
+  tooltip = 'If Always On Resource Map is enabled, keep the tracking button on display instead of hiding it',
   dependsOn = 'hideMinimap',
 } }
 

--- a/Settings/SettingsOptionsTab.lua
+++ b/Settings/SettingsOptionsTab.lua
@@ -200,7 +200,7 @@ local settingsCheckboxOptions = { {
 }, {
   name = 'Always Show Resource Map',
   dbSettingsValueName = 'alwaysShowResourceMap',
-  tooltip = 'Keep the transparent resource map visible in the normal minimap location (shows resource blips only)',
+  tooltip = 'Keep the transparent resource map visible in the normal minimap location (shows resource blips only)\n*Addons that add icons to the minimap could create mouseover issues.',
   dependsOn = 'hideMinimap',
 }, {
   name = 'Show Player Arrow on Resource Map',

--- a/Settings/SettingsOptionsTab.lua
+++ b/Settings/SettingsOptionsTab.lua
@@ -200,7 +200,7 @@ local settingsCheckboxOptions = { {
 }, {
   name = 'Always Show Resource Map',
   dbSettingsValueName = 'alwaysShowResourceMap',
-  tooltip = 'Keep the transparent resource map visible in the normal minimap location (shows resource blips only)\n*Addons that add icons to the minimap could create mouseover issues.',
+  tooltip = 'Keep the transparent resource map visible in the normal minimap location (shows resource blips only).',
   dependsOn = 'hideMinimap',
 }, {
   name = 'Show Player Arrow on Resource Map',
@@ -946,6 +946,16 @@ function InitializeSettingsOptionsTab()
                 checkbox.Text:SetTextColor(0.5, 0.5, 0.5) -- Grey out text
                 checkbox:SetChecked(false)
                 tempSettings[checkboxItem.dbSettingsValueName] = false
+                
+                -- Cascade: update any checkboxes that depend on this one
+                for _, otherCheckboxItem in ipairs(settingsCheckboxOptions) do
+                  if otherCheckboxItem.dependsOn == checkboxItem.dbSettingsValueName then
+                    local otherCheckbox = checkboxes[otherCheckboxItem.dbSettingsValueName]
+                    if otherCheckbox and otherCheckbox._updateDependency then
+                      otherCheckbox._updateDependency()
+                    end
+                  end
+                end
               else
                 checkbox:Enable()
                 checkbox.Text:SetTextColor(1, 1, 1) -- Restore color

--- a/Settings/SettingsOptionsTab.lua
+++ b/Settings/SettingsOptionsTab.lua
@@ -205,6 +205,11 @@ local settingsCheckboxOptions = { {
   dbSettingsValueName = 'showPlayerArrowOnResourceMap',
   tooltip = 'Display the player arrow on the resource tracking map',
   dependsOn = 'alwaysShowResourceMap',
+}, {
+  name = 'Show Tracking Button When Minimap is Hidden',
+  dbSettingsValueName = 'showTrackingButtonEvenWhenMapHidden',
+  tooltip = 'If Hide Minimap is enabled, keep the tracking button on display instead of hiding it',
+  dependsOn = 'hideMinimap',
 } }
 
 -- XP Bar Settings

--- a/UltraHardcore.lua
+++ b/UltraHardcore.lua
@@ -50,6 +50,9 @@ UltraHardcore:SetScript('OnEvent', function(self, event, ...)
       SetVitalsOverlayEnabled(GLOBAL_SETTINGS.showVitalsOverlay or false)
     end
     
+    if GLOBAL_SETTINGS.showTrackingButtonEvenWhenMapHidden and GLOBAL_SETTINGS.hideMinimap then
+        ShowTrackingButton()
+    end
     if GLOBAL_SETTINGS.showMailEvenWhenMapHidden and GLOBAL_SETTINGS.hideMinimap then
       ShowMail()
     end

--- a/UltraHardcore.lua
+++ b/UltraHardcore.lua
@@ -50,7 +50,7 @@ UltraHardcore:SetScript('OnEvent', function(self, event, ...)
       SetVitalsOverlayEnabled(GLOBAL_SETTINGS.showVitalsOverlay or false)
     end
     
-    if GLOBAL_SETTINGS.showTrackingButtonEvenWhenMapHidden and GLOBAL_SETTINGS.hideMinimap then
+    if GLOBAL_SETTINGS.showTrackingWhenMapHidden and GLOBAL_SETTINGS.hideMinimap then
         ShowTrackingButton()
     end
     if GLOBAL_SETTINGS.showMailEvenWhenMapHidden and GLOBAL_SETTINGS.hideMinimap then


### PR DESCRIPTION
**MAKE SURE TO HIDE WHITESPACE SOME JANKERY HAPPENED WITH THE MAIN FILE**


### Summary

- Adds support for displaying and repositioning the tracking button separately when minimap is hidden (same as clock/mail)
- Prevents tracking button from being hidden when "Always On" resource map is enabled
- Adds `/resettrackingposition` (`/rtp`) slash command
- Normalizes line endings (CRLF → LF to match rest of project)

### Screenshots / Video (optional)

<img width="244" height="379" alt="image" src="https://github.com/user-attachments/assets/54ff40df-4288-473a-8d8c-3978e86b563b" />

<img width="625" height="221" alt="image" src="https://github.com/user-attachments/assets/31de9276-ff3f-4357-a307-b7e39da42491" />

### Testing Steps (in-game)

1. Enable "Hide Minimap" + "Show Tracking Button" in settings
2. Test matrix:
   - Enable "Always On Resource Map" - tracking button should remain visible
   - Reload UI (`/reload`)
   - Drag tracking button to new position
   - `/rtp` to reset position
4. Expected result:
   - Tracking button displays independently from minimap
   - Position persists across reloads
   - Dragging works (left-click and drag)


