### PR TITLE
bug/pet-class-resource-bar-display

### DIFF
--- a/Functions/Overlays/CustomResourceBar.lua
+++ b/Functions/Overlays/CustomResourceBar.lua
@@ -653,14 +653,19 @@ local function HandleBuffBarSettingChange()
 end
 
 resourceBar:SetScript('OnEvent', function(self, event, unit)
-  if not GLOBAL_SETTINGS or not GLOBAL_SETTINGS.hidePlayerFrame or GLOBAL_SETTINGS.hideCustomResourceBar then
-    resourceBar:Hide()
-    if ShouldHideComboFrame() then
-      comboFrame:Hide()
+  -- Skip visibility check for pet events - they should only affect pet bar, not player bar
+  local isPetEvent = event == 'UNIT_PET' or event == 'PET_ATTACK_START' or event == 'PET_ATTACK_STOP'
+  
+  if not isPetEvent then
+    if not GLOBAL_SETTINGS or not GLOBAL_SETTINGS.hidePlayerFrame or GLOBAL_SETTINGS.hideCustomResourceBar then
+      resourceBar:Hide()
+      if ShouldHideComboFrame() then
+        comboFrame:Hide()
+      end
+      petResourceBar:Hide()
+      druidFormResourceBar:Hide()
+      return
     end
-    petResourceBar:Hide()
-    druidFormResourceBar:Hide()
-    return
   end
 
   if event == 'PLAYER_LOGIN' and unit == 'Blizzard_BuffFrame' then


### PR DESCRIPTION
### Summary

- Fixing bug where resource bar gets hidden if you are playing on a pet class and you /reload.

### Testing Steps (in-game)

How to enable/trigger the feature.

1. Test matrix:
   - On develop, use Ultra on a class with a pet.
   - See that after a /reload player resource bar is removed.
   - Pull this code
   - /reload
2. Expected result:
   - Player resource bar should stay visible at all times even if you have a pet class (assuming the correct settings are toggled on)

