### PR TITLE
Change ForceHideFrame for protection function errors.

### DIFF
--- a/Constants/PresetSections.lua
+++ b/Constants/PresetSections.lua
@@ -65,6 +65,7 @@ local PRESET_SECTIONS = { {
     'spookyTunnelVision',
     'roachHearthstoneInPartyCombat',
     'showDruidFormResourceBar',
+    'showSoulshardIndicator',
   },
 }, {
   title = 'XP Bar:',

--- a/Functions/CanGetSoulshard.lua
+++ b/Functions/CanGetSoulshard.lua
@@ -94,45 +94,34 @@ end
 
 local function playerLevelRange(playerLevel)
 	--[[
-	ZD =  5, when Char Level =  1 -  7
-	ZD =  6, when Char Level =  8 -  9
-	ZD =  7, when Char Level = 10 - 11
-	ZD =  8, when Char Level = 12 - 15
-	ZD =  9, when Char Level = 16 - 19 
-	ZD = 11, when Char Level = 20 - 29
-	ZD = 12, when Char Level = 30 - 39
-	ZD = 13, when Char Level = 40 - 44
-	ZD = 14, when Char Level = 45 - 49
-	ZD = 15, when Char Level = 50 - 54
-	ZD = 16, when Char Level = 55 - 59
-	ZD = 17, when Char Level = 60 - 84
+		Credit to Tulhur for providing this level range table:
+		1-10  ┃ Playerlevel-4
+		10-19 ┃ Playerlevel-5
+		20-29 ┃ Playerlevel-6
+		30-39 ┃ Playerlevel-7
+		40-44 ┃ Playerlevel-8
+		45-49 ┃ Playerlevel-10
+		50-55 ┃ Playerlevel-11
+		56-60 ┃ Playerlevel-12
 	]]--
 
 	local levelDifference = 0
-	if playerLevel >= 1 and playerLevel <= 7 then
+	if playerLevel >= 1 and playerLevel <= 9 then
+		levelDifference = 4
+	elseif playerLevel >= 10 and playerLevel <= 19 then
 		levelDifference = 5
-	elseif playerLevel >= 8 and playerLevel <= 9 then
-		levelDifference = 6
-	elseif playerLevel >= 10 and playerLevel <= 11 then
-		levelDifference = 7
-	elseif playerLevel >= 12 and playerLevel <= 15 then
-		levelDifference = 8
-	elseif playerLevel >= 16 and playerLevel <= 19 then
-		levelDifference = 9
 	elseif playerLevel >= 20 and playerLevel <= 29 then
-		levelDifference = 11
+		levelDifference = 6
 	elseif playerLevel >= 30 and playerLevel <= 39 then
-		levelDifference = 12
+		levelDifference = 7
 	elseif playerLevel >= 40 and playerLevel <= 44 then
-		levelDifference = 13
+		levelDifference = 8
 	elseif playerLevel >= 45 and playerLevel <= 49 then
-		levelDifference = 14
-	elseif playerLevel >= 50 and playerLevel <= 54 then
-		levelDifference = 15
-	elseif playerLevel >= 55 and playerLevel <= 59 then
-		levelDifference = 16
-	elseif playerLevel >= 60 and playerLevel <= 84 then
-		levelDifference = 17
+		levelDifference = 10
+	elseif playerLevel >= 50 and playerLevel <= 55 then
+		levelDifference = 11
+	elseif playerLevel >= 56 and playerLevel <= 60 then
+		levelDifference = 12
 	end
 	return levelDifference
 end

--- a/Functions/CanGetSoulshard.lua
+++ b/Functions/CanGetSoulshard.lua
@@ -1,0 +1,150 @@
+-- Soulshard Icon Frame
+local soulshardsFrame = CreateFrame("Frame", "UltraHardcoreSoulshardsFrame", UIParent)
+soulshardsFrame:SetSize(32, 32)
+-- Position above the custom resource bar (which is at BOTTOM 140)
+soulshardsFrame:SetPoint("BOTTOM", UIParent, "BOTTOM", 0, 215)
+soulshardsFrame:SetFrameStrata("MEDIUM")
+soulshardsFrame:SetClampedToScreen(true)
+soulshardsFrame:EnableMouse(true)
+soulshardsFrame:SetMovable(true)
+soulshardsFrame:RegisterForDrag("LeftButton")
+soulshardsFrame:SetScript("OnDragStart", soulshardsFrame.StartMoving)
+soulshardsFrame:SetScript("OnDragStop", soulshardsFrame.StopMovingOrSizing)
+
+local soulshardsIcon = soulshardsFrame:CreateTexture(nil, "ARTWORK")
+soulshardsIcon:SetAllPoints()
+soulshardsIcon:SetTexture("Interface\\Icons\\spell_shadow_felmending")
+soulshardsFrame.icon = soulshardsIcon
+
+-- Tooltip for soulshard icon
+soulshardsFrame:SetScript("OnEnter", function(self)
+	GameTooltip:SetOwner(self, "ANCHOR_TOP")
+	GameTooltip:SetText("Soulshard Harvestable", 1, 1, 1)
+	GameTooltip:AddLine("This enemy will grant a soulshard upon defeat", 0.7, 0.7, 0.7)
+	GameTooltip:Show()
+end)
+
+soulshardsFrame:SetScript("OnLeave", function(self)
+	GameTooltip:Hide()
+end)
+
+
+-- You can change this to anything. I used the felmending icon for visibility.
+local SOULSHARD_ICON_PATH = "Interface\\Icons\\spell_shadow_felmending"
+
+-- Function to check if player is a warlock
+local function IsPlayerWarlock()
+	local _, classToken = UnitClass("player")
+	return classToken == "WARLOCK"
+end
+
+--[[ Function to check if player can gain experience from target
+    If we already have a function like this elsewhere, we can reuse it.
+    Returns true if target exists and is valid for XP gain ]]
+local function CanGainXPFromTarget()
+	if not UnitExists("target") then
+		return false
+	end
+
+	if UnitIsDead("target") then
+		return false
+	end
+
+	if UnitIsPlayer("target") then
+		return false
+	end
+
+	if UnitIsFriend("player", "target") then
+		return false
+	end
+
+	-- Don't gain XP from trivial enemies (grey names)
+	-- UnitLevel returns nil for invalid units
+	local targetLevel = UnitLevel("target")
+	if not targetLevel or targetLevel < 0 then
+		return false
+	end
+
+	local playerLevel = UnitLevel("player")
+
+	-- For levels below 10, consider all enemies valid, the player doesn't have soul siphon spell yet
+	if playerLevel < 10 then
+		return true
+	end
+
+	-- For level 10+, check the level difference threshold
+	-- This varies by expansion, but we use this formula based on WoW mechanics -> Thanks to @tulhur for the table reference
+	local levelDifference = 0
+	if playerLevel >= 10 and playerLevel <= 19 then
+		levelDifference = 5
+	elseif playerLevel >= 20 and playerLevel <= 29 then
+		levelDifference = 6
+	elseif playerLevel >= 30 and playerLevel <= 39 then
+		levelDifference = 7
+	elseif playerLevel >= 40 and playerLevel <= 44 then
+		levelDifference = 8
+	elseif playerLevel >= 45 and playerLevel <= 49 then
+		levelDifference = 10
+	elseif playerLevel >= 50 and playerLevel <= 55 then
+		levelDifference = 11
+	elseif playerLevel >= 56 and playerLevel <= 60 then
+		levelDifference = 12
+	end
+
+	-- Target is trivial only if it's MORE than levelDifference levels below
+	-- So a target at (playerLevel - levelDifference) is still worth XP
+	if targetLevel < (playerLevel - levelDifference) then
+		return false
+	end
+
+	return true
+end
+
+-- Function to check if player can get a soulshard from current target
+-- This checks both conditions: is warlock AND can gain XP from target
+function CanGetSoulshardFromTarget()
+	return IsPlayerWarlock() and CanGainXPFromTarget()
+end
+
+-- Function to update soulshard icon visibility
+local function UpdateSoulshardsIcon()
+	if CanGetSoulshardFromTarget() then
+		soulshardsFrame:Show()
+	else
+		soulshardsFrame:Hide()
+	end
+end
+
+
+local updateFrame = CreateFrame("Frame")
+updateFrame:RegisterEvent("PLAYER_TARGET_CHANGED")
+updateFrame:RegisterEvent("UNIT_LEVEL")
+updateFrame:RegisterEvent("PLAYER_LOGIN")
+updateFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
+updateFrame:RegisterEvent("UNIT_HEALTH")
+
+updateFrame:SetScript("OnEvent", function(self, event, unit)
+	-- Always update on target change and login events
+	if event == "PLAYER_TARGET_CHANGED" or event == "PLAYER_LOGIN" or event == "PLAYER_ENTERING_WORLD" then
+		UpdateSoulshardsIcon()
+		return
+	end
+	
+	-- Update on level changes for player or target
+	if event == "UNIT_LEVEL" and (unit == "player" or unit == "target") then
+		UpdateSoulshardsIcon()
+		return
+	end
+	
+	-- Update on health changes for target (catches death and respawn)
+	if event == "UNIT_HEALTH" and unit == "target" then
+		UpdateSoulshardsIcon()
+		return
+	end
+end)
+
+
+-- Export functions globally so other modules can use them
+_G.CanGetSoulshardFromTarget = CanGetSoulshardFromTarget
+_G.IsPlayerWarlock = IsPlayerWarlock
+_G.CanGainXPFromTarget = CanGainXPFromTarget

--- a/Functions/CanGetSoulshard.lua
+++ b/Functions/CanGetSoulshard.lua
@@ -79,18 +79,64 @@ end)
 LoadSoulshardPosition()
 
 
-
-
 -- You can change this to anything. I used the felmending icon for visibility.
 local SOULSHARD_ICON_PATH = "Interface\\Icons\\spell_shadow_felmending"
 
---[[ 
-commented out because of suggestion by @tulhur
-Function to check if player is a warlock
-local function IsPlayerWarlock()
-	local _, classToken = UnitClass("player")
-	return classToken == "WARLOCK"
-end ]]
+
+local function playerKnowsDrainSoul()
+	    -- Check if player knows the Drain Soul spell (required for soulshard harvesting)
+    local playerKnowsDrainSoul = isSpellKnown(1120) 
+    if not playerKnowsDrainSoul then
+        return false
+	end
+	return true
+end
+
+local function playerLevelRange(playerLevel)
+	--[[
+	ZD =  5, when Char Level =  1 -  7
+	ZD =  6, when Char Level =  8 -  9
+	ZD =  7, when Char Level = 10 - 11
+	ZD =  8, when Char Level = 12 - 15
+	ZD =  9, when Char Level = 16 - 19 
+	ZD = 11, when Char Level = 20 - 29
+	ZD = 12, when Char Level = 30 - 39
+	ZD = 13, when Char Level = 40 - 44
+	ZD = 14, when Char Level = 45 - 49
+	ZD = 15, when Char Level = 50 - 54
+	ZD = 16, when Char Level = 55 - 59
+	ZD = 17, when Char Level = 60 - 84
+	]]--
+
+	local levelDifference = 0
+	if playerLevel >= 1 and playerLevel <= 7 then
+		levelDifference = 5
+	elseif playerLevel >= 8 and playerLevel <= 9 then
+		levelDifference = 6
+	elseif playerLevel >= 10 and playerLevel <= 11 then
+		levelDifference = 7
+	elseif playerLevel >= 12 and playerLevel <= 15 then
+		levelDifference = 8
+	elseif playerLevel >= 16 and playerLevel <= 19 then
+		levelDifference = 9
+	elseif playerLevel >= 20 and playerLevel <= 29 then
+		levelDifference = 11
+	elseif playerLevel >= 30 and playerLevel <= 39 then
+		levelDifference = 12
+	elseif playerLevel >= 40 and playerLevel <= 44 then
+		levelDifference = 13
+	elseif playerLevel >= 45 and playerLevel <= 49 then
+		levelDifference = 14
+	elseif playerLevel >= 50 and playerLevel <= 54 then
+		levelDifference = 15
+	elseif playerLevel >= 55 and playerLevel <= 59 then
+		levelDifference = 16
+	elseif playerLevel >= 60 and playerLevel <= 84 then
+		levelDifference = 17
+	end
+	return levelDifference
+end
+
 
 --[[ Function to check if player can gain experience from target
     If we already have a function like this elsewhere, we can reuse it.
@@ -121,36 +167,11 @@ local function CanGainXPFromTarget()
 
 	local playerLevel = UnitLevel("player")
 
-    -- Check if player knows the Drain Soul spell (required for soulshard harvesting)
-    local playerKnowsDrainSoul = isSpellKnown(1120) 
-    if not playerKnowsDrainSoul then
-        return false
-    end
-
-
-
-	-- For level 10+, check the level difference threshold
-	-- This varies by expansion, but we use this formula based on WoW mechanics -> Thanks to @tulhur for the table reference
-	local levelDifference = 0
-	if playerLevel >= 10 and playerLevel <= 19 then
-		levelDifference = 5
-	elseif playerLevel >= 20 and playerLevel <= 29 then
-		levelDifference = 6
-	elseif playerLevel >= 30 and playerLevel <= 39 then
-		levelDifference = 7
-	elseif playerLevel >= 40 and playerLevel <= 44 then
-		levelDifference = 8
-	elseif playerLevel >= 45 and playerLevel <= 49 then
-		levelDifference = 10
-	elseif playerLevel >= 50 and playerLevel <= 55 then
-		levelDifference = 11
-	elseif playerLevel >= 56 and playerLevel <= 60 then
-		levelDifference = 12
-	end
-
+	local levelDifference = playerLevelRange(playerLevel)
+	
 	-- Target is trivial only if it's MORE than levelDifference levels below
 	-- So a target at (playerLevel - levelDifference) is still worth XP
-	if targetLevel < (playerLevel - levelDifference) and not playerKnowsDrainSoul then
+	if targetLevel < (playerLevel - levelDifference) then
 		return false
 	end
 
@@ -160,8 +181,7 @@ end
 -- Function to check if player can get a soulshard from current target
 -- This checks both conditions: is warlock AND can gain XP from target
 function CanGetSoulshardFromTarget()
-	-- return IsPlayerWarlock() and CanGainXPFromTarget()
-	return CanGainXPFromTarget()
+	return CanGainXPFromTarget() and playerKnowsDrainSoul()
 end
 
 -- Function to update soulshard icon visibility
@@ -215,5 +235,4 @@ end
 
 -- Export functions globally so other modules can use them
 _G.CanGetSoulshardFromTarget = CanGetSoulshardFromTarget
--- _G.IsPlayerWarlock = IsPlayerWarlock
 _G.CanGainXPFromTarget = CanGainXPFromTarget

--- a/Functions/CanGetSoulshard.lua
+++ b/Functions/CanGetSoulshard.lua
@@ -8,8 +8,6 @@ soulshardsFrame:SetClampedToScreen(true)
 soulshardsFrame:EnableMouse(true)
 soulshardsFrame:SetMovable(true)
 soulshardsFrame:RegisterForDrag("LeftButton")
-soulshardsFrame:SetScript("OnDragStart", soulshardsFrame.StartMoving)
-soulshardsFrame:SetScript("OnDragStop", soulshardsFrame.StopMovingOrSizing)
 
 local soulshardsIcon = soulshardsFrame:CreateTexture(nil, "ARTWORK")
 soulshardsIcon:SetAllPoints()
@@ -18,25 +16,81 @@ soulshardsFrame.icon = soulshardsIcon
 
 -- Tooltip for soulshard icon
 soulshardsFrame:SetScript("OnEnter", function(self)
-	GameTooltip:SetOwner(self, "ANCHOR_TOP")
-	GameTooltip:SetText("Soulshard Harvestable", 1, 1, 1)
-	GameTooltip:AddLine("This enemy will grant a soulshard upon defeat", 0.7, 0.7, 0.7)
-	GameTooltip:Show()
+    GameTooltip:SetOwner(self, "ANCHOR_TOP")
+    GameTooltip:SetText("Soulshard Harvestable", 1, 1, 1)
+    GameTooltip:AddLine("This enemy will grant a soulshard upon defeat", 0.7, 0.7, 0.7)
+    GameTooltip:Show()
 end)
 
 soulshardsFrame:SetScript("OnLeave", function(self)
-	GameTooltip:Hide()
+    GameTooltip:Hide()
 end)
+
+-- Position persistence functions
+local function SaveSoulshardPosition()
+    if not UltraHardcoreDB then
+        UltraHardcoreDB = {}
+    end
+
+    local point, _, relPoint, x, y = soulshardsFrame:GetPoint()
+    UltraHardcoreDB.soulshardPosition = { point = point, relPoint = relPoint, x = x, y = y }
+end
+
+local function LoadSoulshardPosition()
+    if not UltraHardcoreDB then
+        UltraHardcoreDB = {}
+    end
+
+    local pos = UltraHardcoreDB.soulshardPosition
+    soulshardsFrame:ClearAllPoints()
+    if pos then
+        local point = pos.point or "BOTTOM"
+        local relPoint = pos.relPoint or "BOTTOM"
+        local x = pos.x or 0
+        local y = pos.y or 215
+        soulshardsFrame:SetPoint(point, UIParent, relPoint, x, y)
+    else
+        soulshardsFrame:SetPoint("BOTTOM", UIParent, "BOTTOM", 0, 215)
+    end
+end
+
+local function ResetSoulshardPosition()
+    soulshardsFrame:ClearAllPoints()
+    soulshardsFrame:SetPoint("BOTTOM", UIParent, "BOTTOM", 0, 215)
+    if UltraHardcoreDB then
+        UltraHardcoreDB.soulshardPosition = nil
+    end
+    print("|cfff44336[ULTRA]|r Soulshard Indicator position reset.")
+end
+
+-- Drag handlers with lock support
+soulshardsFrame:SetScript("OnDragStart", function(self)
+    if GLOBAL_SETTINGS and not GLOBAL_SETTINGS.lockSoulshardPosition then
+        self:StartMoving()
+    end
+end)
+
+soulshardsFrame:SetScript("OnDragStop", function(self)
+    self:StopMovingOrSizing()
+    SaveSoulshardPosition()
+end)
+
+-- Load position on initialization
+LoadSoulshardPosition()
+
+
 
 
 -- You can change this to anything. I used the felmending icon for visibility.
 local SOULSHARD_ICON_PATH = "Interface\\Icons\\spell_shadow_felmending"
 
--- Function to check if player is a warlock
+--[[ 
+commented out because of suggestion by @tulhur
+Function to check if player is a warlock
 local function IsPlayerWarlock()
 	local _, classToken = UnitClass("player")
 	return classToken == "WARLOCK"
-end
+end ]]
 
 --[[ Function to check if player can gain experience from target
     If we already have a function like this elsewhere, we can reuse it.
@@ -67,10 +121,13 @@ local function CanGainXPFromTarget()
 
 	local playerLevel = UnitLevel("player")
 
-	-- For levels below 10, consider all enemies valid, the player doesn't have soul siphon spell yet
-	if playerLevel < 10 then
-		return true
-	end
+    -- Check if player knows the Drain Soul spell (required for soulshard harvesting)
+    local playerKnowsDrainSoul = isSpellKnown(1120) 
+    if not playerKnowsDrainSoul then
+        return false
+    end
+
+
 
 	-- For level 10+, check the level difference threshold
 	-- This varies by expansion, but we use this formula based on WoW mechanics -> Thanks to @tulhur for the table reference
@@ -93,7 +150,7 @@ local function CanGainXPFromTarget()
 
 	-- Target is trivial only if it's MORE than levelDifference levels below
 	-- So a target at (playerLevel - levelDifference) is still worth XP
-	if targetLevel < (playerLevel - levelDifference) then
+	if targetLevel < (playerLevel - levelDifference) and not playerKnowsDrainSoul then
 		return false
 	end
 
@@ -103,15 +160,21 @@ end
 -- Function to check if player can get a soulshard from current target
 -- This checks both conditions: is warlock AND can gain XP from target
 function CanGetSoulshardFromTarget()
-	return IsPlayerWarlock() and CanGainXPFromTarget()
+	-- return IsPlayerWarlock() and CanGainXPFromTarget()
+	return CanGainXPFromTarget()
 end
 
 -- Function to update soulshard icon visibility
 local function UpdateSoulshardsIcon()
-	if CanGetSoulshardFromTarget() then
+    if not GLOBAL_SETTINGS.showSoulshardIndicator then
+        soulshardsFrame:Hide()
+        return
+	elseif CanGetSoulshardFromTarget() then
 		soulshardsFrame:Show()
+        return
 	else
 		soulshardsFrame:Hide()
+        return
 	end
 end
 
@@ -143,8 +206,14 @@ updateFrame:SetScript("OnEvent", function(self, event, unit)
 	end
 end)
 
+-- Slash commands for soulshard position reset
+SLASH_ULTRAHARDCORESOULSHARDRESET1 = "/uhcresetsoulshardindicator"
+SLASH_ULTRAHARDCORESOULSHARDRESET2 = "/uhcsi"
+SlashCmdList["ULTRAHARDCORESOULSHARDRESET"] = function(msg)
+    ResetSoulshardPosition()
+end
 
 -- Export functions globally so other modules can use them
 _G.CanGetSoulshardFromTarget = CanGetSoulshardFromTarget
-_G.IsPlayerWarlock = IsPlayerWarlock
+-- _G.IsPlayerWarlock = IsPlayerWarlock
 _G.CanGainXPFromTarget = CanGainXPFromTarget

--- a/Functions/DB/LoadDBData.lua
+++ b/Functions/DB/LoadDBData.lua
@@ -76,6 +76,7 @@ function LoadDBData()
     guildSelfFound = false,
     groupSelfFound = false,
     showDruidFormResourceBar = true,
+    showSoulshardIndicator = true,
     -- XP Bar
     showExpBar = false,
     showXpBarToolTip = false,

--- a/Functions/Overlays/CustomResourceBar.lua
+++ b/Functions/Overlays/CustomResourceBar.lua
@@ -653,14 +653,19 @@ local function HandleBuffBarSettingChange()
 end
 
 resourceBar:SetScript('OnEvent', function(self, event, unit)
-  if not GLOBAL_SETTINGS or not GLOBAL_SETTINGS.hidePlayerFrame or GLOBAL_SETTINGS.hideCustomResourceBar then
-    resourceBar:Hide()
-    if ShouldHideComboFrame() then
-      comboFrame:Hide()
+  -- Skip visibility check for pet events - they should only affect pet bar, not player bar
+  local isPetEvent = event == 'UNIT_PET' or event == 'PET_ATTACK_START' or event == 'PET_ATTACK_STOP'
+  
+  if not isPetEvent then
+    if not GLOBAL_SETTINGS or not GLOBAL_SETTINGS.hidePlayerFrame or GLOBAL_SETTINGS.hideCustomResourceBar then
+      resourceBar:Hide()
+      if ShouldHideComboFrame() then
+        comboFrame:Hide()
+      end
+      petResourceBar:Hide()
+      druidFormResourceBar:Hide()
+      return
     end
-    petResourceBar:Hide()
-    druidFormResourceBar:Hide()
-    return
   end
 
   if event == 'PLAYER_LOGIN' and unit == 'Blizzard_BuffFrame' then

--- a/Functions/Overlays/CustomResourceBar.lua
+++ b/Functions/Overlays/CustomResourceBar.lua
@@ -148,7 +148,7 @@ if not petResourceBar then
 end
 
 petResourceBar:SetSize(125, PlayerFrameManaBar:GetHeight() - 5)
-petResourceBar:SetPoint('TOP', resourceBar, 'BOTTOM', 0, -5)
+petResourceBar:SetPoint('TOP', resourceBar, 'BOTTOM', 0, -7)
 petResourceBar:SetStatusBarTexture('Interface\\TargetingFrame\\UI-StatusBar')
 petResourceBar:Hide() -- Initially hidden
 -- Add border around pet resource bar
@@ -182,7 +182,7 @@ if not druidFormResourceBar then
   return
 end
 druidFormResourceBar:SetSize(125, PlayerFrameManaBar:GetHeight() - 5)
-druidFormResourceBar:SetPoint('TOP', resourceBar, 'BOTTOM', 0, -5)
+druidFormResourceBar:SetPoint('TOP', resourceBar, 'BOTTOM', 0, -7)
 druidFormResourceBar:SetStatusBarTexture('Interface\\TargetingFrame\\UI-StatusBar')
 druidFormResourceBar:Hide() -- Initially hidden
 -- Add a border around the druid form resource bar
@@ -221,7 +221,7 @@ local function LoadDruidFormResourceBarPosition()
   local pos = UltraHardcoreDB.druidFormResourceBarPosition
   druidFormResourceBar:ClearAllPoints()
   -- Always anchor to the main resource bar, matching the pet bar
-  druidFormResourceBar:SetPoint('TOP', resourceBar, 'BOTTOM', 0, -5)
+  druidFormResourceBar:SetPoint('TOP', resourceBar, 'BOTTOM', 0, -7)
 end
 
 -- Make the druid form resource bar draggable with position saving
@@ -775,7 +775,7 @@ local function ResetDruidFormResourceBarPosition()
   -- Clear existing points first
   druidFormResourceBar:ClearAllPoints()
   -- Anchor to the main resource bar, matching the pet bar
-  druidFormResourceBar:SetPoint('TOP', resourceBar, 'BOTTOM', 0, -5)
+  druidFormResourceBar:SetPoint('TOP', resourceBar, 'BOTTOM', 0, -7)
 end
 
 -- Slash command to reset resource bar position

--- a/Functions/Overlays/ShowSvgIcon.lua
+++ b/Functions/Overlays/ShowSvgIcon.lua
@@ -95,3 +95,6 @@ SlashCmdList["UHCSVG"] = function(msg)
 end
 
 
+
+
+

--- a/Functions/SetActionBarVisibility.lua
+++ b/Functions/SetActionBarVisibility.lua
@@ -11,6 +11,9 @@ MIN_LEVEL_HIDE_ACTION_BARS = 6
 ACTIOBAR_FRAMES_TO_HIDE =
   { MainMenuBar, MultiBarBottomLeft, MultiBarBottomRight, MultiBarLeft, MultiBarRight }
 
+-- Store original alpha values for restoration
+local ORIGINAL_ACTION_BAR_ALPHAS = {}
+
 --[[
   Main functions
 ]]
@@ -33,13 +36,24 @@ end
 
 function HideActionBars()
   for _, frame in ipairs(ACTIOBAR_FRAMES_TO_HIDE) do
-    ForceHideFrame(frame)
+    if frame and frame.SetAlpha then
+      -- Store original alpha if not already stored
+      if ORIGINAL_ACTION_BAR_ALPHAS[frame] == nil then
+        ORIGINAL_ACTION_BAR_ALPHAS[frame] = frame:GetAlpha()
+      end
+      -- Hide using alpha instead of ForceHideFrame for better performance
+      frame:SetAlpha(0)
+    end
   end
 end
 
 function ShowActionBars()
   for _, frame in ipairs(ACTIOBAR_FRAMES_TO_HIDE) do
-    RestoreAndShowFrame(frame)
+    if frame and frame.SetAlpha then
+      -- Restore original alpha or default to 1.0
+      local originalAlpha = ORIGINAL_ACTION_BAR_ALPHAS[frame] or 1.0
+      frame:SetAlpha(originalAlpha)
+    end
   end
 end
 

--- a/Functions/SetPetFrameDisplay.lua
+++ b/Functions/SetPetFrameDisplay.lua
@@ -1,0 +1,70 @@
+-- All things Pet
+
+local HIDEABLE_PET_ELEMENTS = {
+  "PetFrameHealthBar",
+  "PetFrameHealthBarText",
+  "PetFrameHealthBarTextLeft",
+  "PetFrameHealthBarTextRight",
+  "PetFrameManaBar",
+  "PetFrameManaBarText",
+  "PetFrameManaBarTextLeft",
+  "PetFrameManaBarTextRight",
+  "PetFrameCombatText",
+  "PetFrameFloatingCombatText",
+  "PetName",
+  "PetFrameTexture",
+  "PetFrameBackground",
+  "PetAttackModeTexture",
+}
+
+-- Optional: disable pet combat text
+function DisablePetCombatText()
+  local elements = {
+    "PetFrameHealthBarText",
+    "PetFrameManaBarText",
+    "PetFrameCombatText",
+    "PetFrameFloatingCombatText",
+  }
+  
+  for _, name in ipairs(elements) do
+    local e = _G[name]
+    if e then
+      e:SetAlpha(0)
+      e:Hide()
+      e.Show = function() end
+    end
+  end
+  
+  COMBATFEEDBACK_FADEINTIME = 0
+  COMBATFEEDBACK_HOLDTIME = 0
+  COMBATFEEDBACK_FADEOUTTIME = 0
+end
+
+-- Optional: reposition pet happiness
+function RepositionPetHappiness()
+  local tex = PetFrameHappinessTexture
+  if tex and PetFrame then
+    tex:ClearAllPoints()
+    tex:SetPoint("CENTER", PetFrame, "CENTER", -70, -5)
+  end
+end
+
+-- Reposition PetFrameHappinessTexture (combat-safe)
+function RepositionPetHappinessTexture()
+  local happinessTexture = PetFrameHappinessTexture
+  if happinessTexture and PetFrame then
+    happinessTexture:ClearAllPoints()
+    -- Position relative to PetFrame, offset 50-70 pixels to the left, slightly down
+    happinessTexture:SetPoint("CENTER", PetFrame, "CENTER", -70, -5)
+  end
+end
+
+-- Hide pet frame pieces
+if PetFrame then
+  for _, name in ipairs(HIDEABLE_PET_ELEMENTS) do
+    local f = _G[name]
+    if f then
+      f:SetAlpha(0)
+    end
+  end
+end

--- a/Functions/SetPlayerFrameDisplay.lua
+++ b/Functions/SetPlayerFrameDisplay.lua
@@ -1,257 +1,59 @@
-local healthBarPosition = nil
+-- Player frame
 
-local function SetStatusTextDisplay(setStatusTextDisplayToNone)
-  if setStatusTextDisplayToNone then
-    SetCVar('statusText', '0')
-    SetCVar('statusTextDisplay', 'NONE')
-  end
-end
+-- Mask that lets us know what parts to show
+local playerMask = {}
 
-local function HideCharacterPanelText()
-  -- Hide HP/mana text elements in character panel that overlap with our XP bars
-  local textElementsToHide =
-    {
-      'PlayerFrameHealthBarText',
-      'PlayerFrameManaBarText',
-      'PetFrameHealthBarText',
-      'PetFrameManaBarText',
-    }
+-- Subframes / elements we want to control
+local PLAYER_HIDEABLE = {
+  "PlayerFrameHealthBar",
+  "PlayerFrameHealthBarText",
+  "PlayerFrameHealthBarTextLeft",
+  "PlayerFrameHealthBarTextRight",
+  "PlayerFrameManaBar",
+  "PlayerFrameManaBarText",
+  "PlayerFrameManaBarTextLeft",
+  "PlayerFrameManaBarTextRight",
+  "PlayerName",
+  "PlayerFrameTexture",
+  "PlayerStatusTexture",
+  "PlayerFrameBackground",
+}
 
-  for _, elementName in ipairs(textElementsToHide) do
-    local element = _G[elementName]
-    if element then
-      element:SetAlpha(0)
+-- Apply mask to PlayerFrame
+local function ApplyPlayerMask()
+  -- Show everything (default blizzard frames)
+  if playerMask.all then return end
+
+  -- Hide/alpha all standard hideable elements
+  for _, name in ipairs(PLAYER_HIDEABLE) do
+    local f = _G[name]
+    if f then
+      if name == "PlayerStatusTexture" then
+        -- This will hide the name glow in rested areas
+        PlayerStatusTexture:SetTexture(nil)
+      end
+      f:SetAlpha(0)
     end
   end
 end
 
-local function HidePlayerFrameHealthMana()
-  -- Store health bar position before hiding it
-  if PlayerFrameHealthBar and not healthBarPosition then
-    local point, relativeTo, relativePoint, xOfs, yOfs = PlayerFrameHealthBar:GetPoint()
-    healthBarPosition = {
-      point = point,
-      relativeTo = relativeTo,
-      relativePoint = relativePoint,
-      xOfs = xOfs,
-      yOfs = yOfs,
-      width = PlayerFrameHealthBar:GetWidth(),
-      height = PlayerFrameHealthBar:GetHeight(),
-    }
-  end
 
-  -- No need to store pet frame positions since we are not creating a replacement
+-- Hook into Blizzard updates
+hooksecurefunc("PlayerFrame_Update", ApplyPlayerMask)
 
-  -- Hide player health and mana bars
-  if PlayerFrameHealthBar then
-    PlayerFrameHealthBar:SetAlpha(0)
-  end
-  if PlayerFrameManaBar then
-    PlayerFrameManaBar:SetAlpha(0)
-  end
-
-  -- Hide player frame texture and background
-  if PlayerFrameTexture then
-    PlayerFrameTexture:SetAlpha(0)
-  end
-  if PlayerFrameBackground then
-    PlayerFrameBackground:SetAlpha(0)
-  end
-
-  -- Hide player level text
-  if PlayerLevelText then
-    PlayerLevelText:SetAlpha(0)
-  end
-
-  -- Hide player and pet names on the player frame
-  if PlayerName then
-    PlayerName:SetAlpha(0)
-  end
-  if PetName then
-    PetName:SetAlpha(0)
-  end
-
-  -- Hide player status texture (resting/combat overlay)
-  if PlayerStatusTexture then
-    ForceHideFrame(PlayerStatusTexture)
-  end
-
-  -- Hide pet health and mana bars
-  if PetFrameHealthBar then
-    PetFrameHealthBar:SetAlpha(0)
-  end
-  if PetFrameManaBar then
-    PetFrameManaBar:SetAlpha(0)
-  end
-
-  -- Hide pet frame texture and background
-  if PetFrameTexture then
-    PetFrameTexture:SetAlpha(0)
-  end
-  if PetFrameBackground then
-    PetFrameBackground:SetAlpha(0)
-  end
-
-  -- Hide pet attack mode texture
-  if PetAttackModeTexture then
-    PetAttackModeTexture:SetAlpha(0)
-  end
-
-  -- Keep main XP bar normal (no modifications)
-
-  -- Hide HP/mana text in character panel that overlaps with our XP bars
-  HideCharacterPanelText()
-end
-
-local function ShowCharacterPanelText()
-  -- Show HP/mana text elements in character panel
-  local textElementsToShow =
-    {
-      'PlayerFrameHealthBarText',
-      'PlayerFrameManaBarText',
-      'PetFrameHealthBarText',
-      'PetFrameManaBarText',
-    }
-
-  for _, elementName in ipairs(textElementsToShow) do
-    local element = _G[elementName]
-    if element then
-      RestoreAndShowFrame(element)
-    end
-  end
-end
-
-local function ShowPlayerFrameHealthMana()
-  -- Show player health bar
-  if PlayerFrameHealthBar then
-    RestoreAndShowFrame(PlayerFrameHealthBar)
-  end
-
-  -- Restore player frame texture and background
-  if PlayerFrameTexture then
-    RestoreAndShowFrame(PlayerFrameTexture)
-  end
-  if PlayerFrameBackground then
-    RestoreAndShowFrame(PlayerFrameBackground)
-  end
-
-  -- Restore player level text
-  if PlayerLevelText then
-    RestoreAndShowFrame(PlayerLevelText)
-  end
-
-  -- No XP bar replacement to manage
-
-  -- Show pet health bar
-  if PetFrameHealthBar then
-    RestoreAndShowFrame(PetFrameHealthBar)
-  end
-  -- Show pet mana bar
-  if PetFrameManaBar then
-    RestoreAndShowFrame(PetFrameManaBar)
-  end
-
-  -- Restore pet frame texture and background
-  if PetFrameTexture then
-    RestoreAndShowFrame(PetFrameTexture)
-  end
-  if PetFrameBackground then
-    RestoreAndShowFrame(PetFrameBackground)
-  end
-
-  -- Restore pet attack mode texture
-  if PetAttackModeTexture then
-    RestoreAndShowFrame(PetAttackModeTexture)
-  end
-
-  -- Keep main XP bar normal (no modifications needed)
-
-  -- Show HP/mana text in character panel
-  ShowCharacterPanelText()
-end
-
-function SetPlayerFrameDisplay(minimalFrameDisplay, completelyRemove)
-  if minimalFrameDisplay then
-    if completelyRemove then
-      -- Completely hide the entire player frame
-      CompletelyHidePlayerFrame()
-    else
-      HidePlayerFrameHealthMana()
-    end
-    -- Set Interface Status Text to None when hiding player frame
-    SetStatusTextDisplay(true)
+function SetPlayerFrameDisplay()
+  -- Setup Player frame options
+  if GLOBAL_SETTINGS.hidePlayerFrame then
+    -- Only show the portrait
+    playerMask.portrait = true
   else
-    if completelyRemove then
-      -- Completely restore the entire player frame
-      CompletelyShowPlayerFrame()
-      SetStatusTextDisplay(false)
-    else
-      ShowPlayerFrameHealthMana()
-      -- Restore Interface Status Text when showing player frame
-      SetStatusTextDisplay(false)
-    end
+    -- Show all (default player frame)
+    playerMask.all = true
   end
-end
-
-function DisablePetCombatText()
-  -- Disable floating combat text over pet frame
-  local petCombatTextElements =
-    {
-      'PetFrameHealthBarText',
-      'PetFrameManaBarText',
-      'PetFrameCombatText',
-      'PetFrameFloatingCombatText',
-    }
-
-  for _, elementName in ipairs(petCombatTextElements) do
-    local element = _G[elementName]
-    if element then
-      -- Set alpha to 0 to hide the text
-      element:SetAlpha(0)
-      -- Prevent the text from being shown
-      element:Hide()
-      -- Override the Show function to prevent it from appearing
-      element.Show = function() end
-    end
-  end
-
-  -- Disable combat feedback timing to prevent incoming pet damage text
-  COMBATFEEDBACK_FADEINTIME = 0
-  COMBATFEEDBACK_HOLDTIME = 0
-  COMBATFEEDBACK_FADEOUTTIME = 0
-end
-
-function CompletelyHidePlayerFrame()
-  -- Hide the entire PlayerFrame
-  if PlayerFrame then
+  if GLOBAL_SETTINGS.completelyRemovePlayerFrame then
+    -- Completely hide the Player Frame 
     ForceHideFrame(PlayerFrame)
+    return
   end
-
-  -- Hide pet frame as well
-  if PetFrame then
-    ForceHideFrame(PetFrame)
-  end
-end
-
-function CompletelyShowPlayerFrame()
-  -- Show the entire PlayerFrame
-  if PlayerFrame then
-    RestoreAndShowFrame(PlayerFrame)
-  end
-
-  -- Show pet frame as well
-  if PetFrame then
-    RestoreAndShowFrame(PetFrame)
-  end
-end
-
-function RepositionPetHappinessTexture()
-  -- Move PetFrameHappinessTexture 50 pixels to the left
-  local happinessTexture = PetFrameHappinessTexture
-  if happinessTexture then
-    -- Clear any existing points to avoid conflicts
-    happinessTexture:ClearAllPoints()
-    -- Position relative to PetFrame, 50 pixels to the left of its default position
-    happinessTexture:SetPoint('CENTER', PetFrame, 'CENTER', -70, -5)
-  end
+  ApplyPlayerMask()
 end

--- a/Functions/SetPlayerFrameDisplay.lua
+++ b/Functions/SetPlayerFrameDisplay.lua
@@ -170,6 +170,11 @@ local function ShowPlayerFrameHealthMana()
   ShowCharacterPanelText()
 end
 
+--[[
+  completelyRemove BUGS:
+  - In combat, ToT turns on during certain combat events when
+--]]
+
 function SetPlayerFrameDisplay(minimalFrameDisplay, completelyRemove)
   if minimalFrameDisplay then
     if completelyRemove then

--- a/Functions/SetPlayerFrameDisplay.lua
+++ b/Functions/SetPlayerFrameDisplay.lua
@@ -1,262 +1,59 @@
-local healthBarPosition = nil
+-- Player frame
 
-local function SetStatusTextDisplay(setStatusTextDisplayToNone)
-  if setStatusTextDisplayToNone then
-    SetCVar('statusText', '0')
-    SetCVar('statusTextDisplay', 'NONE')
-  end
-end
+-- Mask that lets us know what parts to show
+local playerMask = {}
 
-local function HideCharacterPanelText()
-  -- Hide HP/mana text elements in character panel that overlap with our XP bars
-  local textElementsToHide =
-    {
-      'PlayerFrameHealthBarText',
-      'PlayerFrameManaBarText',
-      'PetFrameHealthBarText',
-      'PetFrameManaBarText',
-    }
+-- Subframes / elements we want to control
+local PLAYER_HIDEABLE = {
+  "PlayerFrameHealthBar",
+  "PlayerFrameHealthBarText",
+  "PlayerFrameHealthBarTextLeft",
+  "PlayerFrameHealthBarTextRight",
+  "PlayerFrameManaBar",
+  "PlayerFrameManaBarText",
+  "PlayerFrameManaBarTextLeft",
+  "PlayerFrameManaBarTextRight",
+  "PlayerName",
+  "PlayerFrameTexture",
+  "PlayerStatusTexture",
+  "PlayerFrameBackground",
+}
 
-  for _, elementName in ipairs(textElementsToHide) do
-    local element = _G[elementName]
-    if element then
-      element:SetAlpha(0)
+-- Apply mask to PlayerFrame
+local function ApplyPlayerMask()
+  -- Show everything (default blizzard frames)
+  if playerMask.all then return end
+
+  -- Hide/alpha all standard hideable elements
+  for _, name in ipairs(PLAYER_HIDEABLE) do
+    local f = _G[name]
+    if f then
+      if name == "PlayerStatusTexture" then
+        -- This will hide the name glow in rested areas
+        PlayerStatusTexture:SetTexture(nil)
+      end
+      f:SetAlpha(0)
     end
   end
 end
 
-local function HidePlayerFrameHealthMana()
-  -- Store health bar position before hiding it
-  if PlayerFrameHealthBar and not healthBarPosition then
-    local point, relativeTo, relativePoint, xOfs, yOfs = PlayerFrameHealthBar:GetPoint()
-    healthBarPosition = {
-      point = point,
-      relativeTo = relativeTo,
-      relativePoint = relativePoint,
-      xOfs = xOfs,
-      yOfs = yOfs,
-      width = PlayerFrameHealthBar:GetWidth(),
-      height = PlayerFrameHealthBar:GetHeight(),
-    }
-  end
 
-  -- No need to store pet frame positions since we are not creating a replacement
+-- Hook into Blizzard updates
+hooksecurefunc("PlayerFrame_Update", ApplyPlayerMask)
 
-  -- Hide player health and mana bars
-  if PlayerFrameHealthBar then
-    PlayerFrameHealthBar:SetAlpha(0)
-  end
-  if PlayerFrameManaBar then
-    PlayerFrameManaBar:SetAlpha(0)
-  end
-
-  -- Hide player frame texture and background
-  if PlayerFrameTexture then
-    PlayerFrameTexture:SetAlpha(0)
-  end
-  if PlayerFrameBackground then
-    PlayerFrameBackground:SetAlpha(0)
-  end
-
-  -- Hide player level text
-  if PlayerLevelText then
-    PlayerLevelText:SetAlpha(0)
-  end
-
-  -- Hide player and pet names on the player frame
-  if PlayerName then
-    PlayerName:SetAlpha(0)
-  end
-  if PetName then
-    PetName:SetAlpha(0)
-  end
-
-  -- Hide player status texture (resting/combat overlay)
-  if PlayerStatusTexture then
-    ForceHideFrame(PlayerStatusTexture)
-  end
-
-  -- Hide pet health and mana bars
-  if PetFrameHealthBar then
-    PetFrameHealthBar:SetAlpha(0)
-  end
-  if PetFrameManaBar then
-    PetFrameManaBar:SetAlpha(0)
-  end
-
-  -- Hide pet frame texture and background
-  if PetFrameTexture then
-    PetFrameTexture:SetAlpha(0)
-  end
-  if PetFrameBackground then
-    PetFrameBackground:SetAlpha(0)
-  end
-
-  -- Hide pet attack mode texture
-  if PetAttackModeTexture then
-    PetAttackModeTexture:SetAlpha(0)
-  end
-
-  -- Keep main XP bar normal (no modifications)
-
-  -- Hide HP/mana text in character panel that overlaps with our XP bars
-  HideCharacterPanelText()
-end
-
-local function ShowCharacterPanelText()
-  -- Show HP/mana text elements in character panel
-  local textElementsToShow =
-    {
-      'PlayerFrameHealthBarText',
-      'PlayerFrameManaBarText',
-      'PetFrameHealthBarText',
-      'PetFrameManaBarText',
-    }
-
-  for _, elementName in ipairs(textElementsToShow) do
-    local element = _G[elementName]
-    if element then
-      RestoreAndShowFrame(element)
-    end
-  end
-end
-
-local function ShowPlayerFrameHealthMana()
-  -- Show player health bar
-  if PlayerFrameHealthBar then
-    RestoreAndShowFrame(PlayerFrameHealthBar)
-  end
-
-  -- Restore player frame texture and background
-  if PlayerFrameTexture then
-    RestoreAndShowFrame(PlayerFrameTexture)
-  end
-  if PlayerFrameBackground then
-    RestoreAndShowFrame(PlayerFrameBackground)
-  end
-
-  -- Restore player level text
-  if PlayerLevelText then
-    RestoreAndShowFrame(PlayerLevelText)
-  end
-
-  -- No XP bar replacement to manage
-
-  -- Show pet health bar
-  if PetFrameHealthBar then
-    RestoreAndShowFrame(PetFrameHealthBar)
-  end
-  -- Show pet mana bar
-  if PetFrameManaBar then
-    RestoreAndShowFrame(PetFrameManaBar)
-  end
-
-  -- Restore pet frame texture and background
-  if PetFrameTexture then
-    RestoreAndShowFrame(PetFrameTexture)
-  end
-  if PetFrameBackground then
-    RestoreAndShowFrame(PetFrameBackground)
-  end
-
-  -- Restore pet attack mode texture
-  if PetAttackModeTexture then
-    RestoreAndShowFrame(PetAttackModeTexture)
-  end
-
-  -- Keep main XP bar normal (no modifications needed)
-
-  -- Show HP/mana text in character panel
-  ShowCharacterPanelText()
-end
-
---[[
-  completelyRemove BUGS:
-  - In combat, ToT turns on during certain combat events when
---]]
-
-function SetPlayerFrameDisplay(minimalFrameDisplay, completelyRemove)
-  if minimalFrameDisplay then
-    if completelyRemove then
-      -- Completely hide the entire player frame
-      CompletelyHidePlayerFrame()
-    else
-      HidePlayerFrameHealthMana()
-    end
-    -- Set Interface Status Text to None when hiding player frame
-    SetStatusTextDisplay(true)
+function SetPlayerFrameDisplay()
+  -- Setup Player frame options
+  if GLOBAL_SETTINGS.hidePlayerFrame then
+    -- Only show the portrait
+    playerMask.portrait = true
   else
-    if completelyRemove then
-      -- Completely restore the entire player frame
-      CompletelyShowPlayerFrame()
-      SetStatusTextDisplay(false)
-    else
-      ShowPlayerFrameHealthMana()
-      -- Restore Interface Status Text when showing player frame
-      SetStatusTextDisplay(false)
-    end
+    -- Show all (default player frame)
+    playerMask.all = true
   end
-end
-
-function DisablePetCombatText()
-  -- Disable floating combat text over pet frame
-  local petCombatTextElements =
-    {
-      'PetFrameHealthBarText',
-      'PetFrameManaBarText',
-      'PetFrameCombatText',
-      'PetFrameFloatingCombatText',
-    }
-
-  for _, elementName in ipairs(petCombatTextElements) do
-    local element = _G[elementName]
-    if element then
-      -- Set alpha to 0 to hide the text
-      element:SetAlpha(0)
-      -- Prevent the text from being shown
-      element:Hide()
-      -- Override the Show function to prevent it from appearing
-      element.Show = function() end
-    end
-  end
-
-  -- Disable combat feedback timing to prevent incoming pet damage text
-  COMBATFEEDBACK_FADEINTIME = 0
-  COMBATFEEDBACK_HOLDTIME = 0
-  COMBATFEEDBACK_FADEOUTTIME = 0
-end
-
-function CompletelyHidePlayerFrame()
-  -- Hide the entire PlayerFrame
-  if PlayerFrame then
+  if GLOBAL_SETTINGS.completelyRemovePlayerFrame then
+    -- Completely hide the Player Frame 
     ForceHideFrame(PlayerFrame)
+    return
   end
-
-  -- Hide pet frame as well
-  if PetFrame then
-    ForceHideFrame(PetFrame)
-  end
-end
-
-function CompletelyShowPlayerFrame()
-  -- Show the entire PlayerFrame
-  if PlayerFrame then
-    RestoreAndShowFrame(PlayerFrame)
-  end
-
-  -- Show pet frame as well
-  if PetFrame then
-    RestoreAndShowFrame(PetFrame)
-  end
-end
-
-function RepositionPetHappinessTexture()
-  -- Move PetFrameHappinessTexture 50 pixels to the left
-  local happinessTexture = PetFrameHappinessTexture
-  if happinessTexture then
-    -- Clear any existing points to avoid conflicts
-    happinessTexture:ClearAllPoints()
-    -- Position relative to PetFrame, 50 pixels to the left of its default position
-    happinessTexture:SetPoint('CENTER', PetFrame, 'CENTER', -70, -5)
-  end
+  ApplyPlayerMask()
 end

--- a/Functions/SetTargetFrameDisplay.lua
+++ b/Functions/SetTargetFrameDisplay.lua
@@ -10,16 +10,29 @@ local maxDebuffs = DEBUFF_MAX_DISPLAY or 16
 local HIDEABLE_SUBFRAMES =
   { 'HealthBar', 'ManaBar', 'Name', 'NameBackground', 'HealthBarText', 'ManaBarText', 'Background' }
 
+-- Cache commonly accessed frames
+local TargetFrame, TargetFrameTextureFrame, TargetFramePortrait
+local TargetFrameToT, TargetFrameToTTextureFrame, TargetFrameToTPortrait
+local TargetFrameTextureFrameRaidTargetIcon
+
+-- Update cached frame references
+local function UpdateCachedFrames()
+  TargetFrame = _G.TargetFrame
+  TargetFrameTextureFrame = _G.TargetFrameTextureFrame
+  TargetFramePortrait = _G.TargetFramePortrait
+  TargetFrameToT = _G.TargetFrameToT
+  TargetFrameToTTextureFrame = _G.TargetFrameToTTextureFrame
+  TargetFrameToTPortrait = _G.TargetFrameToTPortrait
+  TargetFrameTextureFrameRaidTargetIcon = _G.TargetFrameTextureFrameRaidTargetIcon
+end
+
 -- Hide all texture regions inside frame except portrait, raid icon
 local function HideTextureRegions(frame)
-  if not frame then return end
-  if targetFrameMask.all then
-    -- Don't hide if we are trying to show all frames, like when in lite mode
-    return
-  end
+  if not frame or targetFrameMask.all then return end
 
-  for i = 1, select('#', frame:GetRegions()) do
-    local region = select(i, frame:GetRegions())
+  local regions = { frame:GetRegions() }
+  for i = 1, #regions do
+    local region = regions[i]
     if region and not region:IsProtected() then
       region:SetAlpha(0)
     end
@@ -27,14 +40,11 @@ local function HideTextureRegions(frame)
 end
 
 -- Apply alpha to hide subframes
-local function HideSubFrames(frame)
-  if targetFrameMask.all then
-    -- don't hide anything if we are trying to show all
-    return
-  end
+local function HideSubFrames(framePrefix)
+  if targetFrameMask.all then return end
 
-  for _, name in ipairs(HIDEABLE_SUBFRAMES) do
-    local f = _G[frame .. name]
+  for i = 1, #HIDEABLE_SUBFRAMES do
+    local f = _G[framePrefix .. HIDEABLE_SUBFRAMES[i]]
     if f and not f:IsProtected() then
       f:SetAlpha(0)
     end
@@ -50,17 +60,20 @@ end
 
 -- Show/hide buffs/debuffs
 local function ApplyAuras()
+  local showBuffs = targetFrameMask.buffs
+  local showDebuffs = targetFrameMask.debuffs
+
   for i = 1, maxBuffs do
     local buff = _G['TargetFrameBuff' .. i]
     if buff then
-      buff:SetAlpha(targetFrameMask.buffs and 1 or 0)
+      buff:SetAlpha(showBuffs and 1 or 0)
     end
   end
 
   for i = 1, maxDebuffs do
     local debuff = _G['TargetFrameDebuff' .. i]
     if debuff then
-      debuff:SetAlpha(targetFrameMask.debuffs and 1 or 0)
+      debuff:SetAlpha(showDebuffs and 1 or 0)
     end
   end
 end
@@ -135,10 +148,7 @@ end
 
 -- Hide all target of target frames (but keep portrait like target frame)
 local function HideTargetOfTargetFrames()
-  if targetFrameMask.all then
-    -- Don't hide if we are trying to show all frames, like when in lite mode
-    return
-  end
+  if targetFrameMask.all then return end
 
   -- Keep the main TargetFrameToT frame visible (same as target frame)
   if TargetFrameToT then
@@ -148,9 +158,38 @@ local function HideTargetOfTargetFrames()
   -- Hide all TargetFrameToT subframes
   HideSubFrames('TargetFrameToT')
 
+  -- Explicitly hide TargetFrameToTBackground
+  local totBackground = _G.TargetFrameToTBackground
+  if totBackground and not totBackground:IsProtected() then
+    totBackground:SetAlpha(0)
+  end
+
+  -- Hide health and mana bar backgrounds (semi-transparent black backgrounds)
+  local totHealthBar = _G.TargetFrameToTHealthBar
+  if totHealthBar then
+    HideTextureRegions(totHealthBar)
+    local healthBarBg = _G.TargetFrameToTHealthBarBackground
+    if healthBarBg and not healthBarBg:IsProtected() then
+      healthBarBg:SetAlpha(0)
+    end
+  end
+
+  local totManaBar = _G.TargetFrameToTManaBar
+  if totManaBar then
+    HideTextureRegions(totManaBar)
+    local manaBarBg = _G.TargetFrameToTManaBarBackground
+    if manaBarBg and not manaBarBg:IsProtected() then
+      manaBarBg:SetAlpha(0)
+    end
+  end
+
   -- Hide texture regions but preserve portrait (same as target frame)
   if TargetFrameToTTextureFrame then
     HideTextureRegions(TargetFrameToTTextureFrame)
+    local totTexture = _G.TargetFrameToTTextureFrameTexture
+    if totTexture and not totTexture:IsProtected() then
+      totTexture:SetAlpha(0)
+    end
   end
 
   -- Show/hide portrait based on mask (same as target frame)
@@ -161,6 +200,9 @@ end
 
 -- Apply the full mask (combat-safe with alpha instead of Show/Hide)
 local function ApplyMask()
+  -- Update cached frames in case they changed
+  UpdateCachedFrames()
+
   if TargetFrame then
     TargetFrame:SetAlpha(1)
   end
@@ -170,7 +212,6 @@ local function ApplyMask()
 
   -- If mask is set to show all, do nothing (show Blizzard default frames)
   if targetFrameMask.all then
-    -- Restore target of target frames when showing all
     if TargetFrameToT then
       TargetFrameToT:SetAlpha(1)
     end
@@ -184,7 +225,6 @@ local function ApplyMask()
     if TargetFrameTextureFrame then
       TargetFrameTextureFrame:SetAlpha(0)
     end
-    -- Also hide target of target when no target exists
     if TargetFrameToT then
       TargetFrameToT:SetAlpha(0)
     end
@@ -220,13 +260,20 @@ function SetTargetFrameDisplay(mask)
     targetFrameEventFrame = CreateFrame('Frame')
     targetFrameEventFrame:RegisterEvent('PLAYER_TARGET_CHANGED')
     targetFrameEventFrame:RegisterEvent('GROUP_ROSTER_UPDATE')
-    targetFrameEventFrame:SetScript('OnEvent', function(_, event, unit)
+    targetFrameEventFrame:RegisterEvent('PLAYER_REGEN_DISABLED') -- entering combat
+    targetFrameEventFrame:SetScript('OnEvent', function(_, event)
       if event == 'PLAYER_TARGET_CHANGED' or event == 'GROUP_ROSTER_UPDATE' then
         ApplyMask()
+      elseif event == 'PLAYER_REGEN_DISABLED' then
+        -- Reapply mask immediately when entering combat
+        ApplyMask()
+        -- Also reapply after a small delay to catch any UI updates
+        C_Timer.After(0.1, ApplyMask)
       end
     end)
   end
 
-  -- Apply mask immediately
+  -- Update cached frames and apply mask immediately
+  UpdateCachedFrames()
   ApplyMask()
 end

--- a/Settings/SettingsOptionsTab.lua
+++ b/Settings/SettingsOptionsTab.lua
@@ -399,15 +399,8 @@ function InitializeSettingsOptionsTab()
     tempSettings.selectedDifficulty = difficultyNames[presetIndex]
     GLOBAL_SETTINGS.selectedDifficulty = difficultyNames[presetIndex]
 
-    if tempSettings.hidePlayerFrame then
-      SetCVar('statusText', '0')
-    end
-
     -- Apply the new completely remove settings immediately when presets are applied
-    SetPlayerFrameDisplay(
-      tempSettings.hidePlayerFrame or false,
-      tempSettings.completelyRemovePlayerFrame or false
-    )
+    SetPlayerFrameDisplay()
 
     if SetVitalsOverlayEnabled then
       SetVitalsOverlayEnabled(tempSettings.showVitalsOverlay or false)
@@ -1017,10 +1010,6 @@ function InitializeSettingsOptionsTab()
             if checkboxItem.dependsOn and not (tempSettings[checkboxItem.dependsOn] or false) then return end
             tempSettings[checkboxItem.dbSettingsValueName] = self:GetChecked()
 
-            if checkboxItem.dbSettingsValueName == 'hidePlayerFrame' and self:GetChecked() then
-              SetCVar('statusText', '0')
-            end
-
             if checkboxItem.dbSettingsValueName == 'buffBarOnResourceBar' or checkboxItem.dbSettingsValueName == 'hidePlayerFrame' then
               if _G.UltraHardcoreHandleBuffBarSettingChange then
                 _G.UltraHardcoreHandleBuffBarSettingChange()
@@ -1284,15 +1273,8 @@ function InitializeSettingsOptionsTab()
       GLOBAL_SETTINGS[key] = value
     end
 
-    if GLOBAL_SETTINGS.hidePlayerFrame then
-      SetCVar('statusText', '0')
-    end
-
     -- Apply the new completely remove settings immediately
-    SetPlayerFrameDisplay(
-      GLOBAL_SETTINGS.hidePlayerFrame or false,
-      GLOBAL_SETTINGS.completelyRemovePlayerFrame or false
-    )
+    SetPlayerFrameDisplay()
 
     -- Set target frame accordingly
     if GLOBAL_SETTINGS.hideTargetFrame or GLOBAL_SETTINGS.completelyRemoveTargetFrame then

--- a/Settings/SettingsOptionsTab.lua
+++ b/Settings/SettingsOptionsTab.lua
@@ -86,18 +86,22 @@ local settingsCheckboxOptions = { {
   name = 'Completely Remove Target Frame',
   dbSettingsValueName = 'completelyRemoveTargetFrame',
   tooltip = 'Completely remove the target frame',
+  dependsOn = 'hideTargetFrame',
 }, {
   name = 'Show Target Buffs',
   dbSettingsValueName = 'showTargetBuffs',
   tooltip = 'Show buffs on the target frame',
+  dependsOn = 'hideTargetFrame',
 }, {
   name = 'Show Target Debuffs',
   dbSettingsValueName = 'showTargetDebuffs',
   tooltip = 'Show debuffs on the target frame',
+  dependsOn = 'hideTargetFrame',
 }, {
   name = 'Show Target Raid Icon',
   dbSettingsValueName = 'showTargetRaidIcon',
   tooltip = 'Show raid icon on the target frame',
+  dependsOn = 'hideTargetFrame',
 }, {
   -- Misc Settings (no preset button)
   name = 'On Screen Statistics',

--- a/Settings/SettingsOptionsTab.lua
+++ b/Settings/SettingsOptionsTab.lua
@@ -407,15 +407,8 @@ function InitializeSettingsOptionsTab()
     tempSettings.selectedDifficulty = difficultyNames[presetIndex]
     GLOBAL_SETTINGS.selectedDifficulty = difficultyNames[presetIndex]
 
-    if tempSettings.hidePlayerFrame then
-      SetCVar('statusText', '0')
-    end
-
     -- Apply the new completely remove settings immediately when presets are applied
-    SetPlayerFrameDisplay(
-      tempSettings.hidePlayerFrame or false,
-      tempSettings.completelyRemovePlayerFrame or false
-    )
+    SetPlayerFrameDisplay()
 
     if SetVitalsOverlayEnabled then
       SetVitalsOverlayEnabled(tempSettings.showVitalsOverlay or false)
@@ -1025,10 +1018,6 @@ function InitializeSettingsOptionsTab()
             if checkboxItem.dependsOn and not (tempSettings[checkboxItem.dependsOn] or false) then return end
             tempSettings[checkboxItem.dbSettingsValueName] = self:GetChecked()
 
-            if checkboxItem.dbSettingsValueName == 'hidePlayerFrame' and self:GetChecked() then
-              SetCVar('statusText', '0')
-            end
-
             if checkboxItem.dbSettingsValueName == 'buffBarOnResourceBar' or checkboxItem.dbSettingsValueName == 'hidePlayerFrame' then
               if _G.UltraHardcoreHandleBuffBarSettingChange then
                 _G.UltraHardcoreHandleBuffBarSettingChange()
@@ -1292,15 +1281,8 @@ function InitializeSettingsOptionsTab()
       GLOBAL_SETTINGS[key] = value
     end
 
-    if GLOBAL_SETTINGS.hidePlayerFrame then
-      SetCVar('statusText', '0')
-    end
-
     -- Apply the new completely remove settings immediately
-    SetPlayerFrameDisplay(
-      GLOBAL_SETTINGS.hidePlayerFrame or false,
-      GLOBAL_SETTINGS.completelyRemovePlayerFrame or false
-    )
+    SetPlayerFrameDisplay()
 
     -- Set target frame accordingly
     if GLOBAL_SETTINGS.hideTargetFrame or GLOBAL_SETTINGS.completelyRemoveTargetFrame then

--- a/Settings/SettingsOptionsTab.lua
+++ b/Settings/SettingsOptionsTab.lua
@@ -194,6 +194,10 @@ local settingsCheckboxOptions = { {
   dbSettingsValueName = 'showDruidFormResourceBar',
   tooltip = 'Show a separate resource bar when shapeshifted as a druid',
 }, {
+  name = 'Show Soulshard Indicator',
+  dbSettingsValueName = 'showSoulshardIndicator',
+  tooltip = 'Display an icon when the current target will drop a soulshard upon defeat (Warlocks only)',
+}, {
   name = 'Always Show Resource Map',
   dbSettingsValueName = 'alwaysShowResourceMap',
   tooltip = 'Keep the transparent resource map visible in the normal minimap location (shows resource blips only).',

--- a/UltraHardcore.lua
+++ b/UltraHardcore.lua
@@ -37,10 +37,8 @@ UltraHardcore:SetScript('OnEvent', function(self, event, ...)
     HidePlayerMapIndicators()
     ShowWelcomeMessage()
     ShowVersionUpdateDialog()
-    SetPlayerFrameDisplay(
-      GLOBAL_SETTINGS.hidePlayerFrame or false,
-      GLOBAL_SETTINGS.completelyRemovePlayerFrame or false
-    )
+    SetPlayerFrameDisplay()
+
     if SetVitalsOverlayEnabled then
       SetVitalsOverlayEnabled(GLOBAL_SETTINGS.showVitalsOverlay or false)
     end

--- a/UltraHardcore.toc
+++ b/UltraHardcore.toc
@@ -18,6 +18,7 @@ Libs/AceSerializer-3.0/AceSerializer-3.0.xml
 ## Functions
 Functions/PlayerComm.lua
 Functions/SetPlayerFrameDisplay.lua
+Functions/SetPetFrameDisplay.lua
 Functions/SetMinimapDisplay.lua
 Functions/SetTargetFrameDisplay.lua
 Functions/SetTargetTooltipDisplay.lua

--- a/UltraHardcore.toc
+++ b/UltraHardcore.toc
@@ -17,6 +17,7 @@ Libs/AceSerializer-3.0/AceSerializer-3.0.xml
 
 ## Functions
 Functions/PlayerComm.lua
+Functions/CanGetSoulshard.lua
 Functions/SetPlayerFrameDisplay.lua
 Functions/SetMinimapDisplay.lua
 Functions/SetTargetFrameDisplay.lua

--- a/UltraHardcore.toc
+++ b/UltraHardcore.toc
@@ -19,6 +19,7 @@ Libs/AceSerializer-3.0/AceSerializer-3.0.xml
 Functions/PlayerComm.lua
 Functions/CanGetSoulshard.lua
 Functions/SetPlayerFrameDisplay.lua
+Functions/SetPetFrameDisplay.lua
 Functions/SetMinimapDisplay.lua
 Functions/SetTargetFrameDisplay.lua
 Functions/SetTargetTooltipDisplay.lua


### PR DESCRIPTION
### Summary

- Changed ForceHideFrame to register/unregister functions and queue changes if in combat.  This gets rid of the action bar hiding errors we were hitting.
- Simplified Player Frame masking.  This also allowed us to stop forcing cvar changes for statusText, which is global for all characters.
- Moved Pet Frame code to it's own file

### Testing

- Test with hide action bars in and out of combat, as well as in a dungeon, and you should no longer hit the protected function errors for multibar hiding, etc...
- Verified, even with Blizzard status text turned on, you don't see the values on the player frame anymore.
- Tested the other users of ForceHideFrame (blizzard xp bar, breath bar)