### PR TITLE
Adjust resource bar position for pet and druid forms

### DIFF
--- a/Functions/Overlays/CustomResourceBar.lua
+++ b/Functions/Overlays/CustomResourceBar.lua
@@ -148,7 +148,7 @@ if not petResourceBar then
 end
 
 petResourceBar:SetSize(125, PlayerFrameManaBar:GetHeight() - 5)
-petResourceBar:SetPoint('TOP', resourceBar, 'BOTTOM', 0, -5)
+petResourceBar:SetPoint('TOP', resourceBar, 'BOTTOM', 0, -7)
 petResourceBar:SetStatusBarTexture('Interface\\TargetingFrame\\UI-StatusBar')
 petResourceBar:Hide() -- Initially hidden
 -- Add border around pet resource bar
@@ -182,7 +182,7 @@ if not druidFormResourceBar then
   return
 end
 druidFormResourceBar:SetSize(125, PlayerFrameManaBar:GetHeight() - 5)
-druidFormResourceBar:SetPoint('TOP', resourceBar, 'BOTTOM', 0, -5)
+druidFormResourceBar:SetPoint('TOP', resourceBar, 'BOTTOM', 0, -7)
 druidFormResourceBar:SetStatusBarTexture('Interface\\TargetingFrame\\UI-StatusBar')
 druidFormResourceBar:Hide() -- Initially hidden
 -- Add a border around the druid form resource bar
@@ -221,7 +221,7 @@ local function LoadDruidFormResourceBarPosition()
   local pos = UltraHardcoreDB.druidFormResourceBarPosition
   druidFormResourceBar:ClearAllPoints()
   -- Always anchor to the main resource bar, matching the pet bar
-  druidFormResourceBar:SetPoint('TOP', resourceBar, 'BOTTOM', 0, -5)
+  druidFormResourceBar:SetPoint('TOP', resourceBar, 'BOTTOM', 0, -7)
 end
 
 -- Make the druid form resource bar draggable with position saving
@@ -775,7 +775,7 @@ local function ResetDruidFormResourceBarPosition()
   -- Clear existing points first
   druidFormResourceBar:ClearAllPoints()
   -- Anchor to the main resource bar, matching the pet bar
-  druidFormResourceBar:SetPoint('TOP', resourceBar, 'BOTTOM', 0, -5)
+  druidFormResourceBar:SetPoint('TOP', resourceBar, 'BOTTOM', 0, -7)
 end
 
 -- Slash command to reset resource bar position


### PR DESCRIPTION
### Summary

- Lowered the position of Pet- and Druid-Manabars by 2 pixels to (0,-7) from (0,-5) to prevent the weird overlap

### Screenshots / Video (optional)

Before:
<img width="405" height="73" alt="image" src="https://github.com/user-attachments/assets/8c2211f0-4db3-4af6-aed8-775c9608616a" />
<img width="41" height="23" alt="image" src="https://github.com/user-attachments/assets/bece42c8-57f6-4621-aa22-a92a3a332443" />

After:
<img width="95" height="101" alt="image" src="https://github.com/user-attachments/assets/66fa514c-e936-4e97-94f2-0099e639b6df" />


### Testing Steps (in-game)

How to enable/trigger the feature.

1. Test matrix:
   - Reload UI (/reload) on any pet-class or druid with druid manabars enabled
   
2. Expected result:
   - The overlap, that's visible when your resource bar is empty is gone