### PR TITLE
PlayerFrame Loop and ForceHideFrame reg/unreg

### DIFF
--- a/Functions/SetPetFrameDisplay.lua
+++ b/Functions/SetPetFrameDisplay.lua
@@ -1,0 +1,70 @@
+-- All things Pet
+
+local HIDEABLE_PET_ELEMENTS = {
+  "PetFrameHealthBar",
+  "PetFrameHealthBarText",
+  "PetFrameHealthBarTextLeft",
+  "PetFrameHealthBarTextRight",
+  "PetFrameManaBar",
+  "PetFrameManaBarText",
+  "PetFrameManaBarTextLeft",
+  "PetFrameManaBarTextRight",
+  "PetFrameCombatText",
+  "PetFrameFloatingCombatText",
+  "PetName",
+  "PetFrameTexture",
+  "PetFrameBackground",
+  "PetAttackModeTexture",
+}
+
+-- Optional: disable pet combat text
+function DisablePetCombatText()
+  local elements = {
+    "PetFrameHealthBarText",
+    "PetFrameManaBarText",
+    "PetFrameCombatText",
+    "PetFrameFloatingCombatText",
+  }
+  
+  for _, name in ipairs(elements) do
+    local e = _G[name]
+    if e then
+      e:SetAlpha(0)
+      e:Hide()
+      e.Show = function() end
+    end
+  end
+  
+  COMBATFEEDBACK_FADEINTIME = 0
+  COMBATFEEDBACK_HOLDTIME = 0
+  COMBATFEEDBACK_FADEOUTTIME = 0
+end
+
+-- Optional: reposition pet happiness
+function RepositionPetHappiness()
+  local tex = PetFrameHappinessTexture
+  if tex and PetFrame then
+    tex:ClearAllPoints()
+    tex:SetPoint("CENTER", PetFrame, "CENTER", -70, -5)
+  end
+end
+
+-- Reposition PetFrameHappinessTexture (combat-safe)
+function RepositionPetHappinessTexture()
+  local happinessTexture = PetFrameHappinessTexture
+  if happinessTexture and PetFrame then
+    happinessTexture:ClearAllPoints()
+    -- Position relative to PetFrame, offset 50-70 pixels to the left, slightly down
+    happinessTexture:SetPoint("CENTER", PetFrame, "CENTER", -70, -5)
+  end
+end
+
+-- Hide pet frame pieces
+if PetFrame then
+  for _, name in ipairs(HIDEABLE_PET_ELEMENTS) do
+    local f = _G[name]
+    if f then
+      f:SetAlpha(0)
+    end
+  end
+end

--- a/Functions/SetPlayerFrameDisplay.lua
+++ b/Functions/SetPlayerFrameDisplay.lua
@@ -1,262 +1,59 @@
-local healthBarPosition = nil
+-- Player frame
 
-local function SetStatusTextDisplay(setStatusTextDisplayToNone)
-  if setStatusTextDisplayToNone then
-    SetCVar('statusText', '0')
-    SetCVar('statusTextDisplay', 'NONE')
-  end
-end
+-- Mask that lets us know what parts to show
+local playerMask = {}
 
-local function HideCharacterPanelText()
-  -- Hide HP/mana text elements in character panel that overlap with our XP bars
-  local textElementsToHide =
-    {
-      'PlayerFrameHealthBarText',
-      'PlayerFrameManaBarText',
-      'PetFrameHealthBarText',
-      'PetFrameManaBarText',
-    }
+-- Subframes / elements we want to control
+local PLAYER_HIDEABLE = {
+  "PlayerFrameHealthBar",
+  "PlayerFrameHealthBarText",
+  "PlayerFrameHealthBarTextLeft",
+  "PlayerFrameHealthBarTextRight",
+  "PlayerFrameManaBar",
+  "PlayerFrameManaBarText",
+  "PlayerFrameManaBarTextLeft",
+  "PlayerFrameManaBarTextRight",
+  "PlayerName",
+  "PlayerFrameTexture",
+  "PlayerStatusTexture",
+  "PlayerFrameBackground",
+}
 
-  for _, elementName in ipairs(textElementsToHide) do
-    local element = _G[elementName]
-    if element then
-      element:SetAlpha(0)
+-- Apply mask to PlayerFrame
+local function ApplyPlayerMask()
+  -- Show everything (default blizzard frames)
+  if playerMask.all then return end
+
+  -- Hide/alpha all standard hideable elements
+  for _, name in ipairs(PLAYER_HIDEABLE) do
+    local f = _G[name]
+    if f then
+      if name == "PlayerStatusTexture" then
+        -- This will hide the name glow in rested areas
+        PlayerStatusTexture:SetTexture(nil)
+      end
+      f:SetAlpha(0)
     end
   end
 end
 
-local function HidePlayerFrameHealthMana()
-  -- Store health bar position before hiding it
-  if PlayerFrameHealthBar and not healthBarPosition then
-    local point, relativeTo, relativePoint, xOfs, yOfs = PlayerFrameHealthBar:GetPoint()
-    healthBarPosition = {
-      point = point,
-      relativeTo = relativeTo,
-      relativePoint = relativePoint,
-      xOfs = xOfs,
-      yOfs = yOfs,
-      width = PlayerFrameHealthBar:GetWidth(),
-      height = PlayerFrameHealthBar:GetHeight(),
-    }
-  end
 
-  -- No need to store pet frame positions since we are not creating a replacement
+-- Hook into Blizzard updates
+hooksecurefunc("PlayerFrame_Update", ApplyPlayerMask)
 
-  -- Hide player health and mana bars
-  if PlayerFrameHealthBar then
-    PlayerFrameHealthBar:SetAlpha(0)
-  end
-  if PlayerFrameManaBar then
-    PlayerFrameManaBar:SetAlpha(0)
-  end
-
-  -- Hide player frame texture and background
-  if PlayerFrameTexture then
-    PlayerFrameTexture:SetAlpha(0)
-  end
-  if PlayerFrameBackground then
-    PlayerFrameBackground:SetAlpha(0)
-  end
-
-  -- Hide player level text
-  if PlayerLevelText then
-    PlayerLevelText:SetAlpha(0)
-  end
-
-  -- Hide player and pet names on the player frame
-  if PlayerName then
-    PlayerName:SetAlpha(0)
-  end
-  if PetName then
-    PetName:SetAlpha(0)
-  end
-
-  -- Hide player status texture (resting/combat overlay)
-  if PlayerStatusTexture then
-    ForceHideFrame(PlayerStatusTexture)
-  end
-
-  -- Hide pet health and mana bars
-  if PetFrameHealthBar then
-    PetFrameHealthBar:SetAlpha(0)
-  end
-  if PetFrameManaBar then
-    PetFrameManaBar:SetAlpha(0)
-  end
-
-  -- Hide pet frame texture and background
-  if PetFrameTexture then
-    PetFrameTexture:SetAlpha(0)
-  end
-  if PetFrameBackground then
-    PetFrameBackground:SetAlpha(0)
-  end
-
-  -- Hide pet attack mode texture
-  if PetAttackModeTexture then
-    PetAttackModeTexture:SetAlpha(0)
-  end
-
-  -- Keep main XP bar normal (no modifications)
-
-  -- Hide HP/mana text in character panel that overlaps with our XP bars
-  HideCharacterPanelText()
-end
-
-local function ShowCharacterPanelText()
-  -- Show HP/mana text elements in character panel
-  local textElementsToShow =
-    {
-      'PlayerFrameHealthBarText',
-      'PlayerFrameManaBarText',
-      'PetFrameHealthBarText',
-      'PetFrameManaBarText',
-    }
-
-  for _, elementName in ipairs(textElementsToShow) do
-    local element = _G[elementName]
-    if element then
-      RestoreAndShowFrame(element)
-    end
-  end
-end
-
-local function ShowPlayerFrameHealthMana()
-  -- Show player health bar
-  if PlayerFrameHealthBar then
-    RestoreAndShowFrame(PlayerFrameHealthBar)
-  end
-
-  -- Restore player frame texture and background
-  if PlayerFrameTexture then
-    RestoreAndShowFrame(PlayerFrameTexture)
-  end
-  if PlayerFrameBackground then
-    RestoreAndShowFrame(PlayerFrameBackground)
-  end
-
-  -- Restore player level text
-  if PlayerLevelText then
-    RestoreAndShowFrame(PlayerLevelText)
-  end
-
-  -- No XP bar replacement to manage
-
-  -- Show pet health bar
-  if PetFrameHealthBar then
-    RestoreAndShowFrame(PetFrameHealthBar)
-  end
-  -- Show pet mana bar
-  if PetFrameManaBar then
-    RestoreAndShowFrame(PetFrameManaBar)
-  end
-
-  -- Restore pet frame texture and background
-  if PetFrameTexture then
-    RestoreAndShowFrame(PetFrameTexture)
-  end
-  if PetFrameBackground then
-    RestoreAndShowFrame(PetFrameBackground)
-  end
-
-  -- Restore pet attack mode texture
-  if PetAttackModeTexture then
-    RestoreAndShowFrame(PetAttackModeTexture)
-  end
-
-  -- Keep main XP bar normal (no modifications needed)
-
-  -- Show HP/mana text in character panel
-  ShowCharacterPanelText()
-end
-
---[[
-  completelyRemove BUGS:
-  - In combat, ToT turns on during certain combat events when
---]]
-
-function SetPlayerFrameDisplay(minimalFrameDisplay, completelyRemove)
-  if minimalFrameDisplay then
-    if completelyRemove then
-      -- Completely hide the entire player frame
-      CompletelyHidePlayerFrame()
-    else
-      HidePlayerFrameHealthMana()
-    end
-    -- Set Interface Status Text to None when hiding player frame
-    SetStatusTextDisplay(true)
+function SetPlayerFrameDisplay()
+  -- Setup Player frame options
+  if GLOBAL_SETTINGS.hidePlayerFrame then
+    -- Only show the portrait
+    playerMask.portrait = true
   else
-    if completelyRemove then
-      -- Completely restore the entire player frame
-      CompletelyShowPlayerFrame()
-      SetStatusTextDisplay(false)
-    else
-      ShowPlayerFrameHealthMana()
-      -- Restore Interface Status Text when showing player frame
-      SetStatusTextDisplay(false)
-    end
+    -- Show all (default player frame)
+    playerMask.all = true
   end
-end
-
-function DisablePetCombatText()
-  -- Disable floating combat text over pet frame
-  local petCombatTextElements =
-    {
-      'PetFrameHealthBarText',
-      'PetFrameManaBarText',
-      'PetFrameCombatText',
-      'PetFrameFloatingCombatText',
-    }
-
-  for _, elementName in ipairs(petCombatTextElements) do
-    local element = _G[elementName]
-    if element then
-      -- Set alpha to 0 to hide the text
-      element:SetAlpha(0)
-      -- Prevent the text from being shown
-      element:Hide()
-      -- Override the Show function to prevent it from appearing
-      element.Show = function() end
-    end
-  end
-
-  -- Disable combat feedback timing to prevent incoming pet damage text
-  COMBATFEEDBACK_FADEINTIME = 0
-  COMBATFEEDBACK_HOLDTIME = 0
-  COMBATFEEDBACK_FADEOUTTIME = 0
-end
-
-function CompletelyHidePlayerFrame()
-  -- Hide the entire PlayerFrame
-  if PlayerFrame then
+  if GLOBAL_SETTINGS.completelyRemovePlayerFrame then
+    -- Completely hide the Player Frame 
     ForceHideFrame(PlayerFrame)
+    return
   end
-
-  -- Hide pet frame as well
-  if PetFrame then
-    ForceHideFrame(PetFrame)
-  end
-end
-
-function CompletelyShowPlayerFrame()
-  -- Show the entire PlayerFrame
-  if PlayerFrame then
-    RestoreAndShowFrame(PlayerFrame)
-  end
-
-  -- Show pet frame as well
-  if PetFrame then
-    RestoreAndShowFrame(PetFrame)
-  end
-end
-
-function RepositionPetHappinessTexture()
-  -- Move PetFrameHappinessTexture 50 pixels to the left
-  local happinessTexture = PetFrameHappinessTexture
-  if happinessTexture then
-    -- Clear any existing points to avoid conflicts
-    happinessTexture:ClearAllPoints()
-    -- Position relative to PetFrame, 50 pixels to the left of its default position
-    happinessTexture:SetPoint('CENTER', PetFrame, 'CENTER', -70, -5)
-  end
+  ApplyPlayerMask()
 end

--- a/Settings/SettingsOptionsTab.lua
+++ b/Settings/SettingsOptionsTab.lua
@@ -407,15 +407,8 @@ function InitializeSettingsOptionsTab()
     tempSettings.selectedDifficulty = difficultyNames[presetIndex]
     GLOBAL_SETTINGS.selectedDifficulty = difficultyNames[presetIndex]
 
-    if tempSettings.hidePlayerFrame then
-      SetCVar('statusText', '0')
-    end
-
     -- Apply the new completely remove settings immediately when presets are applied
-    SetPlayerFrameDisplay(
-      tempSettings.hidePlayerFrame or false,
-      tempSettings.completelyRemovePlayerFrame or false
-    )
+    SetPlayerFrameDisplay()
 
     if SetVitalsOverlayEnabled then
       SetVitalsOverlayEnabled(tempSettings.showVitalsOverlay or false)
@@ -1025,10 +1018,6 @@ function InitializeSettingsOptionsTab()
             if checkboxItem.dependsOn and not (tempSettings[checkboxItem.dependsOn] or false) then return end
             tempSettings[checkboxItem.dbSettingsValueName] = self:GetChecked()
 
-            if checkboxItem.dbSettingsValueName == 'hidePlayerFrame' and self:GetChecked() then
-              SetCVar('statusText', '0')
-            end
-
             if checkboxItem.dbSettingsValueName == 'buffBarOnResourceBar' or checkboxItem.dbSettingsValueName == 'hidePlayerFrame' then
               if _G.UltraHardcoreHandleBuffBarSettingChange then
                 _G.UltraHardcoreHandleBuffBarSettingChange()
@@ -1292,15 +1281,8 @@ function InitializeSettingsOptionsTab()
       GLOBAL_SETTINGS[key] = value
     end
 
-    if GLOBAL_SETTINGS.hidePlayerFrame then
-      SetCVar('statusText', '0')
-    end
-
     -- Apply the new completely remove settings immediately
-    SetPlayerFrameDisplay(
-      GLOBAL_SETTINGS.hidePlayerFrame or false,
-      GLOBAL_SETTINGS.completelyRemovePlayerFrame or false
-    )
+    SetPlayerFrameDisplay()
 
     -- Set target frame accordingly
     if GLOBAL_SETTINGS.hideTargetFrame or GLOBAL_SETTINGS.completelyRemoveTargetFrame then

--- a/UltraHardcore.lua
+++ b/UltraHardcore.lua
@@ -37,10 +37,8 @@ UltraHardcore:SetScript('OnEvent', function(self, event, ...)
     HidePlayerMapIndicators()
     ShowWelcomeMessage()
     ShowVersionUpdateDialog()
-    SetPlayerFrameDisplay(
-      GLOBAL_SETTINGS.hidePlayerFrame or false,
-      GLOBAL_SETTINGS.completelyRemovePlayerFrame or false
-    )
+    SetPlayerFrameDisplay()
+
     if SetVitalsOverlayEnabled then
       SetVitalsOverlayEnabled(GLOBAL_SETTINGS.showVitalsOverlay or false)
     end

--- a/UltraHardcore.toc
+++ b/UltraHardcore.toc
@@ -19,6 +19,7 @@ Libs/AceSerializer-3.0/AceSerializer-3.0.xml
 Functions/PlayerComm.lua
 Functions/CanGetSoulshard.lua
 Functions/SetPlayerFrameDisplay.lua
+Functions/SetPetFrameDisplay.lua
 Functions/SetMinimapDisplay.lua
 Functions/SetTargetFrameDisplay.lua
 Functions/SetTargetTooltipDisplay.lua


### PR DESCRIPTION
### Summary

- Changed ForceHideFrame to register/unregister functions and queue changes if in combat.  This gets rid of the action bar hiding errors we were hitting.
- Simplified Player Frame masking.  This also allowed us to stop forcing cvar changes for statusText, which is global for all characters.
- Moved Pet Frame code to it's own file

### Testing

- Test with hide action bars in and out of combat, as well as in a dungeon, and you should no longer hit the protected function errors for multibar hiding, etc...
- Verified, even with Blizzard status text turned on, you don't see the values on the player frame anymore.
- Tested the other users of ForceHideFrame (blizzard xp bar, breath bar)