### PR TITLE
Hide action bars back to ForceHide

### DIFF
--- a/Functions/SetActionBarVisibility.lua
+++ b/Functions/SetActionBarVisibility.lua
@@ -11,9 +11,6 @@ MIN_LEVEL_HIDE_ACTION_BARS = 6
 ACTIOBAR_FRAMES_TO_HIDE =
   { MainMenuBar, MultiBarBottomLeft, MultiBarBottomRight, MultiBarLeft, MultiBarRight }
 
--- Store original alpha values for restoration
-local ORIGINAL_ACTION_BAR_ALPHAS = {}
-
 --[[
   Main functions
 ]]
@@ -36,24 +33,14 @@ end
 
 function HideActionBars()
   for _, frame in ipairs(ACTIOBAR_FRAMES_TO_HIDE) do
-    if frame and frame.SetAlpha then
-      -- Store original alpha if not already stored
-      if ORIGINAL_ACTION_BAR_ALPHAS[frame] == nil then
-        ORIGINAL_ACTION_BAR_ALPHAS[frame] = frame:GetAlpha()
-      end
-      -- Hide using alpha instead of ForceHideFrame for better performance
-      frame:SetAlpha(0)
-    end
+    -- Force Hide will unregister to avoid protected function errors
+    ForceHideFrame(frame)
   end
 end
 
 function ShowActionBars()
   for _, frame in ipairs(ACTIOBAR_FRAMES_TO_HIDE) do
-    if frame and frame.SetAlpha then
-      -- Restore original alpha or default to 1.0
-      local originalAlpha = ORIGINAL_ACTION_BAR_ALPHAS[frame] or 1.0
-      frame:SetAlpha(originalAlpha)
-    end
+    RestoreAndShowFrame(frame)
   end
 end
 


### PR DESCRIPTION
### Summary

Put hide action bars back to using ForceFrameHide() so it hides GCD glow, tooltips etc.. 
We don't hit protection issues with the recent forcehideframe changes.

### Testing Steps (in-game)

- Enable hide action bars and go into a dungeon and engage in combat. :)