### PR TITLE
Better action bar hiding to prevent mouse events like tooltips

### DIFF
--- a/Functions/SetActionBarVisibility.lua
+++ b/Functions/SetActionBarVisibility.lua
@@ -98,7 +98,7 @@ f:SetScript('OnEvent', function(self, event, ...)
     -- We need a slight delay after getting on a taxi before UnitOnTaxi will return true
     if C_Timer and C_Timer.After then
       C_Timer.After(0.2, function()
-    SetActionBarVisibility(GLOBAL_SETTINGS.hideActionBars)
+        SetActionBarVisibility(GLOBAL_SETTINGS.hideActionBars)
       end)
     end
   end

--- a/Functions/SetActionBarVisibility.lua
+++ b/Functions/SetActionBarVisibility.lua
@@ -95,6 +95,11 @@ f:SetScript('OnEvent', function(self, event, ...)
   elseif event == 'PLAYER_ENTERING_WORLD' then
     SetActionBarVisibility(GLOBAL_SETTINGS.hideActionBars)
   elseif event == 'PLAYER_CONTROL_GAINED' or event == 'PLAYER_CONTROL_LOST' then
+    -- We need a slight delay after getting on a taxi before UnitOnTaxi will return true
+    if C_Timer and C_Timer.After then
+      C_Timer.After(0.2, function()
     SetActionBarVisibility(GLOBAL_SETTINGS.hideActionBars)
+      end)
+    end
   end
 end)

--- a/Functions/SetActionBarVisibility.lua
+++ b/Functions/SetActionBarVisibility.lua
@@ -91,20 +91,10 @@ f:SetScript('OnEvent', function(self, event, ...)
   if event == 'UNIT_AURA' then
     OnPlayerUnitAuraEvent(self, ...)
   elseif event == 'PLAYER_REGEN_DISABLED' or event == 'PLAYER_REGEN_ENABLED' then
-    -- Defer action bar visibility changes when entering/leaving combat to avoid protected frame errors
-    if C_Timer and C_Timer.After then
-      C_Timer.After(0.5, function()
-        SetActionBarVisibility(GLOBAL_SETTINGS.hideActionBars)
-      end)
-    end
+    SetActionBarVisibility(GLOBAL_SETTINGS.hideActionBars)
   elseif event == 'PLAYER_ENTERING_WORLD' then
     SetActionBarVisibility(GLOBAL_SETTINGS.hideActionBars)
   elseif event == 'PLAYER_CONTROL_GAINED' or event == 'PLAYER_CONTROL_LOST' then
-    -- We need a slight delay after getting on a taxi before UnitOnTaxi will return true
-    if C_Timer and C_Timer.After then
-      C_Timer.After(0.2, function()
-        SetActionBarVisibility(GLOBAL_SETTINGS.hideActionBars)
-      end)
-    end
+    SetActionBarVisibility(GLOBAL_SETTINGS.hideActionBars)
   end
 end)

--- a/Functions/Utils/Frame/ForceHideFrame.lua
+++ b/Functions/Utils/Frame/ForceHideFrame.lua
@@ -1,20 +1,44 @@
 local driverQueue = {}
 local inCombat = false
 
+-- A dummy frame we can re-parent other frames to when hiding
+local UltraHiddenParent = CreateFrame("Frame", "UltraHiddenParent", UIParent)
+UltraHiddenParent:Hide()                 -- fully hidden
+UltraHiddenParent:SetAlpha(0)            -- invisible
+UltraHiddenParent:EnableMouse(false)     -- can't be interacted with
+UltraHiddenParent:EnableMouseWheel(false)
+UltraHiddenParent:SetIgnoreParentScale(true)
+UltraHiddenParent:SetIgnoreParentAlpha(true)
+
+
 local function ApplyDriver(frame, state)
-    if type(frame.SetAttribute) ~= "function" then
-        -- not a secure frame, safe fallback to standard hide/show
-        if state == "hide" then 
-            frame:Hide()
-        else
-            frame:Show()
+    if not frame then return end
+
+    -- Reparent-hide: safest way to kill visibility & mouse input
+    if state == "hide" then
+        if not frame._UltraOriginalParent then
+            frame._UltraOriginalParent = frame:GetParent()
         end
+
+        -- Detach from all secure visibility systems
+        UnregisterStateDriver(frame, "visibility")
+
+        -- Reparent to the hidden dummy
+        frame:SetParent(UltraHiddenParent)
+        frame:Hide()
         return
     end
 
-    -- Change visiblity of a secure frame
-    UnregisterStateDriver(frame, "visibility")
-    RegisterStateDriver(frame, "visibility", state)
+    -- Restore original parent
+    if state == "show" then
+        if frame._UltraOriginalParent then
+            frame:SetParent(frame._UltraOriginalParent)
+        end
+
+        frame:Show()
+        return
+    end
+
 end
 
 local function QueueDriver(frame, state)


### PR DESCRIPTION
### Summary

Better ForceHideFrame()
- When hiding a frame, we will reparent it to a dummy frame that is hidden and has all mouse interaction disabled.
- When we restore, we put it back to its original parent and state.


### Testing Steps (in-game)

Turn on hide action bars and mouse over where the buttons were.  You should no longer see tooltip flashing.

