### PR TITLE
Udpated all dragable UI components to be resetable. Added a reset all…

### DIFF
--- a/Functions/CanGetSoulshard.lua
+++ b/Functions/CanGetSoulshard.lua
@@ -64,6 +64,9 @@ local function ResetSoulshardPosition()
     print("|cfff44336[ULTRA]|r Soulshard Indicator position reset.")
 end
 
+-- Make ResetSoulshardPosition globally accessible for combined reset commands
+_G.ResetSoulshardPosition = ResetSoulshardPosition
+
 -- Drag handlers with lock support
 soulshardsFrame:SetScript("OnDragStart", function(self)
     if GLOBAL_SETTINGS and not GLOBAL_SETTINGS.lockSoulshardPosition then

--- a/Functions/Overlays/CustomResourceBar.lua
+++ b/Functions/Overlays/CustomResourceBar.lua
@@ -772,8 +772,11 @@ local function ResetResourceBarPosition()
   resourceBar:SetPoint('CENTER', UIParent, 'BOTTOM', 0, 140)
   -- Save the reset position
   SaveResourceBarPosition()
-  print('UltraHardcore: Resource bar position reset to default')
+  print('|cfff44336[ULTRA]|r Resource bar position reset to default.')
 end
+
+-- Make ResetResourceBarPosition globally accessible for combined reset commands
+_G.ResetResourceBarPosition = ResetResourceBarPosition
 
 -- Reset druid form resource bar position function
 local function ResetDruidFormResourceBarPosition()

--- a/Functions/Overlays/MainScreenStatistics.lua
+++ b/Functions/Overlays/MainScreenStatistics.lua
@@ -666,6 +666,22 @@ local function ResetStatsFrameToSavedPosition()
   print('UltraHardcore: Statistics panel moved to saved position')
 end
 
+-- Reset statistics frame to default position
+local function ResetStatsFramePosition()
+  statsFrame:ClearAllPoints()
+  statsFrame:SetPoint('TOPLEFT', UIParent, 'TOPLEFT', 130, -10)
+  if UltraHardcoreDB then
+    UltraHardcoreDB.statsFramePosition = nil
+  end
+  if SaveDBData then
+    SaveDBData('statsFramePosition', nil)
+  end
+  print('|cfff44336[ULTRA]|r Statistics panel position reset to default.')
+end
+
+-- Make ResetStatsFramePosition globally accessible for combined reset commands
+_G.ResetStatsFramePosition = ResetStatsFramePosition
+
 SLASH_UHCSTATSRESET1 = '/uhcstatsreset'
 SLASH_UHCSTATSRESET2 = '/uhcsr'
 SlashCmdList['UHCSTATSRESET'] = ResetStatsFrameToSavedPosition

--- a/Functions/Overlays/UpdateResourceIndicator.lua
+++ b/Functions/Overlays/UpdateResourceIndicator.lua
@@ -32,6 +32,22 @@ local function LoadResourceIndicatorPosition()
   end
 end
 
+-- Reset resource indicator position function
+local function ResetResourceIndicatorPosition()
+  resourceIndicator:ClearAllPoints()
+  resourceIndicator:SetPoint('BOTTOMRIGHT', UIParent, 'BOTTOMRIGHT', -20, 70)
+  if UltraHardcoreDB then
+    UltraHardcoreDB.resourceIndicatorPosition = nil
+  end
+  if SaveDBData then
+    SaveDBData('resourceIndicatorPosition', nil)
+  end
+  print('|cfff44336[ULTRA]|r Resource indicator position reset to default.')
+end
+
+-- Make ResetResourceIndicatorPosition globally accessible for combined reset commands
+_G.ResetResourceIndicatorPosition = ResetResourceIndicatorPosition
+
 -- Make draggable and save position
 resourceIndicator:EnableMouse(true)
 resourceIndicator:RegisterForDrag('LeftButton')

--- a/Functions/SetMinimapDisplay.lua
+++ b/Functions/SetMinimapDisplay.lua
@@ -508,7 +508,7 @@ local function ResetClockPosition()
   local point, _, relPoint, x, y = TimeManagerClockButton:GetPoint()
   UltraHardcoreDB.minimapClockPosition = { point = point, relPoint = relPoint, x = x, y = y }
   SaveDBData('minimapClockPosition', UltraHardcoreDB.minimapClockPosition)
-  print('UltraHardcore: clock position reset to default')
+  print('|cfff44336[ULTRA]|r Clock position reset to default.')
 end
 
 -- Reset mail position function
@@ -538,7 +538,7 @@ local function ResetMailPosition()
   local point, _, relPoint, x, y = MiniMapMailFrame:GetPoint()
   UltraHardcoreDB.minimapMailPosition = { point = point, relPoint = relPoint, x = x, y = y }
   SaveDBData('minimapMailPosition', UltraHardcoreDB.minimapMailPosition)
-  print('UltraHardcore: Mail position reset to default')
+  print('|cfff44336[ULTRA]|r Mail position reset to default.')
 end
 
 -- Reset tracking position function
@@ -567,7 +567,7 @@ local function ResetTrackingPosition()
   local point, _, relPoint, x, y = MiniMapTracking:GetPoint()
   UltraHardcoreDB.MiniMapTrackingPosition = { point = point, relPoint = relPoint, x = x, y = y }
   SaveDBData('MiniMapTrackingPosition', UltraHardcoreDB.MiniMapTrackingPosition)
-  print('UltraHardcore: Tracking position reset to default')
+  print('|cfff44336[ULTRA]|r Tracking position reset to default.')
 end
 
 -- Slash command to reset clock position

--- a/Functions/Utils/ConfirmationDialog.lua
+++ b/Functions/Utils/ConfirmationDialog.lua
@@ -76,16 +76,6 @@ function ShowConfirmationDialog(title, message, onConfirm, onCancel, confirmText
     cancelButton:SetSize(100, 30)
     cancelButton:SetPoint('BOTTOM', confirmationDialog, 'BOTTOM', 70, 16)
     confirmationDialog.cancelButton = cancelButton
-
-    -- Close on escape
-    confirmationDialog:SetScript('OnKeyDown', function(self, key)
-      if key == 'ESCAPE' then
-        self:Hide()
-        if self.onCancel then
-          self.onCancel()
-        end
-      end
-    end)
   end
 
   -- Update dialog content
@@ -121,15 +111,12 @@ function ShowConfirmationDialog(title, message, onConfirm, onCancel, confirmText
 
   -- Show dialog
   confirmationDialog:Show()
-  confirmationDialog:EnableKeyboard(true)
-  confirmationDialog:SetFocus()
 end
 
 -- Hide the confirmation dialog
 function HideConfirmationDialog()
   if confirmationDialog then
     confirmationDialog:Hide()
-    confirmationDialog:EnableKeyboard(false)
   end
 end
 

--- a/Functions/Utils/ConfirmationDialog.lua
+++ b/Functions/Utils/ConfirmationDialog.lua
@@ -1,0 +1,139 @@
+-- Reusable Confirmation Dialog Utility
+-- Provides a simple, clean confirmation dialog that can be reused throughout the addon
+
+local confirmationDialog = nil
+
+-- Show a confirmation dialog
+-- @param title string - The title of the dialog
+-- @param message string - The message to display
+-- @param onConfirm function - Callback when user confirms
+-- @param onCancel function (optional) - Callback when user cancels
+-- @param confirmText string (optional) - Text for confirm button (default: "Confirm")
+-- @param cancelText string (optional) - Text for cancel button (default: "Cancel")
+function ShowConfirmationDialog(title, message, onConfirm, onCancel, confirmText, cancelText)
+  confirmText = confirmText or 'Confirm'
+  cancelText = cancelText or 'Cancel'
+
+  -- Create dialog if it doesn't exist
+  if not confirmationDialog then
+    confirmationDialog = CreateFrame('Frame', 'UltraHardcoreConfirmationDialog', UIParent, 'BackdropTemplate')
+    confirmationDialog:SetFrameStrata('FULLSCREEN_DIALOG')
+    confirmationDialog:SetFrameLevel(100)
+    confirmationDialog:SetToplevel(true)
+    confirmationDialog:SetSize(400, 120)
+    confirmationDialog:SetPoint('CENTER', UIParent, 'CENTER', 0, 0)
+    confirmationDialog:SetMovable(true)
+    confirmationDialog:EnableMouse(true)
+    confirmationDialog:RegisterForDrag('LeftButton')
+    confirmationDialog:SetScript('OnDragStart', function(self)
+      self:StartMoving()
+    end)
+    confirmationDialog:SetScript('OnDragStop', function(self)
+      self:StopMovingOrSizing()
+    end)
+
+    -- Background
+    local bg = confirmationDialog:CreateTexture(nil, 'BACKGROUND')
+    bg:SetAllPoints()
+    bg:SetColorTexture(0, 0, 0, 0.9)
+    confirmationDialog:SetBackdrop({
+      edgeFile = 'Interface\\DialogFrame\\UI-DialogBox-Border',
+      tile = false,
+      edgeSize = 16,
+      insets = {
+        left = 4,
+        right = 4,
+        top = 4,
+        bottom = 4,
+      },
+    })
+    confirmationDialog:SetBackdropBorderColor(0.6, 0.6, 0.6, 1)
+
+    -- Title
+    local titleText = confirmationDialog:CreateFontString(nil, 'OVERLAY', 'GameFontNormalLarge')
+    titleText:SetPoint('TOP', confirmationDialog, 'TOP', 0, -16)
+    titleText:SetText(title)
+    titleText:SetJustifyH('CENTER')
+    confirmationDialog.titleText = titleText
+
+    -- Message
+    local messageText = confirmationDialog:CreateFontString(nil, 'OVERLAY', 'GameFontHighlight')
+    messageText:SetPoint('TOP', titleText, 'BOTTOM', 0, -12)
+    messageText:SetWidth(360)
+    messageText:SetJustifyH('CENTER')
+    messageText:SetJustifyV('TOP')
+    messageText:SetNonSpaceWrap(true)
+    confirmationDialog.messageText = messageText
+
+    -- Confirm button
+    local confirmButton = CreateFrame('Button', nil, confirmationDialog, 'UIPanelButtonTemplate')
+    confirmButton:SetSize(140, 30)
+    confirmButton:SetPoint('BOTTOM', confirmationDialog, 'BOTTOM', -70, 16)
+    confirmationDialog.confirmButton = confirmButton
+
+    -- Cancel button
+    local cancelButton = CreateFrame('Button', nil, confirmationDialog, 'UIPanelButtonTemplate')
+    cancelButton:SetSize(100, 30)
+    cancelButton:SetPoint('BOTTOM', confirmationDialog, 'BOTTOM', 70, 16)
+    confirmationDialog.cancelButton = cancelButton
+
+    -- Close on escape
+    confirmationDialog:SetScript('OnKeyDown', function(self, key)
+      if key == 'ESCAPE' then
+        self:Hide()
+        if self.onCancel then
+          self.onCancel()
+        end
+      end
+    end)
+  end
+
+  -- Update dialog content
+  confirmationDialog.titleText:SetText(title)
+  confirmationDialog.messageText:SetText(message)
+  confirmationDialog.confirmButton:SetText(confirmText)
+  confirmationDialog.cancelButton:SetText(cancelText)
+
+  -- Auto-size dialog based on message (estimate based on line count)
+  local lineCount = math.ceil(#message / 50) -- Rough estimate: ~50 chars per line
+  local minHeight = 120
+  local calculatedHeight = math.max(minHeight, 80 + (lineCount * 15) + 50) -- Title + message lines + buttons
+  confirmationDialog:SetHeight(calculatedHeight)
+
+  -- Set callbacks
+  confirmationDialog.onConfirm = onConfirm
+  confirmationDialog.onCancel = onCancel
+
+  -- Button handlers
+  confirmationDialog.confirmButton:SetScript('OnClick', function()
+    confirmationDialog:Hide()
+    if confirmationDialog.onConfirm then
+      confirmationDialog.onConfirm()
+    end
+  end)
+
+  confirmationDialog.cancelButton:SetScript('OnClick', function()
+    confirmationDialog:Hide()
+    if confirmationDialog.onCancel then
+      confirmationDialog.onCancel()
+    end
+  end)
+
+  -- Show dialog
+  confirmationDialog:Show()
+  confirmationDialog:EnableKeyboard(true)
+  confirmationDialog:SetFocus()
+end
+
+-- Hide the confirmation dialog
+function HideConfirmationDialog()
+  if confirmationDialog then
+    confirmationDialog:Hide()
+    confirmationDialog:EnableKeyboard(false)
+  end
+end
+
+-- Make functions globally accessible
+_G.ShowConfirmationDialog = ShowConfirmationDialog
+_G.HideConfirmationDialog = HideConfirmationDialog
+

--- a/Functions/Utils/ResetUI.lua
+++ b/Functions/Utils/ResetUI.lua
@@ -36,6 +36,11 @@ local function ResetUI()
     _G.ResetStatsFramePosition()
   end
   
+  -- Reset ULTRA Menu frame
+  if _G.ResetULTRAMenuFramesPosition then
+    _G.ResetULTRAMenuFramesPosition()
+  end
+  
   print('|cfff44336[ULTRA]|r All UI element positions reset to default.')
 end
 

--- a/Functions/Utils/ResetUI.lua
+++ b/Functions/Utils/ResetUI.lua
@@ -1,0 +1,49 @@
+-- Global UI Reset Utility
+-- Handles resetting all draggable UI elements to their default positions
+
+-- Combined reset function for all draggable UI elements
+local function ResetUI()
+  -- Reset minimap elements (these are local functions, so we call via slash commands)
+  if SlashCmdList['RESETCLOCKPOSITION'] then
+    SlashCmdList['RESETCLOCKPOSITION']()
+  end
+  if SlashCmdList['RESETMAILPOSITION'] then
+    SlashCmdList['RESETMAILPOSITION']()
+  end
+  if SlashCmdList['RESETTRACKINGPOSITION'] then
+    SlashCmdList['RESETTRACKINGPOSITION']()
+  end
+  
+  -- Reset resource bar
+  if _G.ResetResourceBarPosition then
+    _G.ResetResourceBarPosition()
+  elseif SlashCmdList['RESETRESOURCEBAR'] then
+    SlashCmdList['RESETRESOURCEBAR']()
+  end
+  
+  -- Reset resource indicator
+  if _G.ResetResourceIndicatorPosition then
+    _G.ResetResourceIndicatorPosition()
+  end
+  
+  -- Reset soulshard indicator
+  if _G.ResetSoulshardPosition then
+    _G.ResetSoulshardPosition()
+  end
+  
+  -- Reset statistics panel
+  if _G.ResetStatsFramePosition then
+    _G.ResetStatsFramePosition()
+  end
+  
+  print('|cfff44336[ULTRA]|r All UI element positions reset to default.')
+end
+
+-- Slash command to reset UI elements
+SLASH_RESETUI1 = '/resetui'
+SLASH_RESETUI2 = '/rui'
+SlashCmdList['RESETUI'] = ResetUI
+
+-- Make ResetUI globally accessible
+_G.ResetUI = ResetUI
+

--- a/Settings/CommandsTab.lua
+++ b/Settings/CommandsTab.lua
@@ -158,7 +158,7 @@ function InitializeCommandsTab()
       { '/resetresourcebar, /rrb', 'Reset the custom resource bar to its default position.' },
       {
         '/resetui, /rui',
-        'Reset all draggable UI element positions to default (clock, mail, tracking, resource bar, resource indicator, soulshard indicator, and statistics panel).',
+        'Reset all draggable UI element positions to default (ULTRA Menu, clock, mail, tracking, resource bar, resource indicator, soulshard indicator, and statistics panel).',
       },
     },
   } }

--- a/Settings/CommandsTab.lua
+++ b/Settings/CommandsTab.lua
@@ -156,6 +156,10 @@ function InitializeCommandsTab()
         'Reset the minimap tracking button to the default position.',
       },
       { '/resetresourcebar, /rrb', 'Reset the custom resource bar to its default position.' },
+      {
+        '/resetui, /rui',
+        'Reset all draggable UI element positions to default (clock, mail, tracking, resource bar, resource indicator, soulshard indicator, and statistics panel).',
+      },
     },
   } }
 

--- a/Settings/Settings.lua
+++ b/Settings/Settings.lua
@@ -70,6 +70,12 @@ end)
 settingsFrame:SetScript('OnDragStop', function(self)
   self:StopMovingOrSizing()
 end)
+settingsFrame:SetScript('OnHide', function(self)
+  -- Close confirmation dialog if open when settings window is hidden
+  if _G.HideConfirmationDialog then
+    _G.HideConfirmationDialog()
+  end
+end)
 settingsFrame:SetPoint('CENTER', UIParent, 'CENTER', 0, 30)
 
 -- Reset ULTRA Menu frame to default position
@@ -164,6 +170,10 @@ closeButton:SetScript('OnClick', function()
     _G.tbcContentFrame:Hide()
   end
   initializeTempSettings()
+  -- Close confirmation dialog if open
+  if _G.HideConfirmationDialog then
+    _G.HideConfirmationDialog()
+  end
   settingsFrame:Hide()
 end)
 closeButton:SetNormalTexture('Interface\\AddOns\\UltraHardcore\\Textures\\header-x.png')
@@ -185,6 +195,10 @@ function ToggleSettings()
     end
     if _G.tbcContentFrame then
       _G.tbcContentFrame:Hide()
+    end
+    -- Close confirmation dialog if open
+    if _G.HideConfirmationDialog then
+      _G.HideConfirmationDialog()
     end
     settingsFrame:Hide()
   else

--- a/Settings/Settings.lua
+++ b/Settings/Settings.lua
@@ -71,6 +71,17 @@ settingsFrame:SetScript('OnDragStop', function(self)
   self:StopMovingOrSizing()
 end)
 settingsFrame:SetPoint('CENTER', UIParent, 'CENTER', 0, 30)
+
+-- Reset ULTRA Menu frame to default position
+local function ResetULTRAMenuFramesPosition()
+  settingsFrame:ClearAllPoints()
+  settingsFrame:SetPoint('CENTER', UIParent, 'CENTER', 0, 30)
+  -- WoW will automatically save this position via UISpecialFrames
+  print('|cfff44336[ULTRA]|r ULTRA Menu position reset to default.')
+end
+
+-- Make ResetULTRAMenuFramesPosition globally accessible for combined reset commands
+_G.ResetULTRAMenuFramesPosition = ResetULTRAMenuFramesPosition
 settingsFrame:Hide()
 settingsFrame:SetFrameStrata('DIALOG')
 settingsFrame:SetFrameLevel(15)

--- a/Settings/SettingsOptionsTab.lua
+++ b/Settings/SettingsOptionsTab.lua
@@ -1272,21 +1272,10 @@ function InitializeSettingsOptionsTab()
     _G.__UHC_SectionTitles = sectionTitles
   end
 
-  -- Create buttons centered at the bottom
-  local resetUIButton = CreateFrame('Button', nil, tabContents[2], 'UIPanelButtonTemplate')
-  resetUIButton:SetSize(140, 30)
-  resetUIButton:SetText('Reset Positions')
-  resetUIButton:SetPoint('BOTTOM', tabContents[2], 'BOTTOM', -77.5, -40)
-
   local saveButton = CreateFrame('Button', nil, tabContents[2], 'UIPanelButtonTemplate')
-  saveButton:SetSize(150, 30)
+  saveButton:SetSize(120, 30)
+  saveButton:SetPoint('BOTTOM', tabContents[2], 'BOTTOM', 0, -40)
   saveButton:SetText('Save and Reload')
-  saveButton:SetPoint('LEFT', resetUIButton, 'RIGHT', 10, 0)
-  resetUIButton:SetScript('OnClick', function()
-    if SlashCmdList['RESETUI'] then
-      SlashCmdList['RESETUI']()
-    end
-  end)
   saveButton:SetScript('OnClick', function()
     for key, value in pairs(tempSettings) do
       GLOBAL_SETTINGS[key] = value
@@ -2146,6 +2135,36 @@ function InitializeSettingsOptionsTab()
     end
   end
 
+  -- Add reset button at the bottom of UI settings section
+  local resetUIButton = CreateFrame('Button', nil, colorSectionFrame, 'UIPanelButtonTemplate')
+  resetUIButton:SetSize(140, 30)
+  resetUIButton:SetText('Reset Positions')
+  resetUIButton:SetPoint('BOTTOM', colorSectionFrame, 'BOTTOM', 0, 10)
+  resetUIButton:SetScript('OnClick', function()
+    if SlashCmdList['RESETUI'] then
+      SlashCmdList['RESETUI']()
+    end
+  end)
+  resetUIButton:SetScript('OnEnter', function(self)
+    GameTooltip:SetOwner(self, 'ANCHOR_TOP')
+    GameTooltip:SetText('Reset Positions', 1, 1, 1)
+    GameTooltip:AddLine('Resets the following to default positions:', 1, 1, 1, true)
+    GameTooltip:AddLine('• Clock', 0.8, 0.8, 0.8)
+    GameTooltip:AddLine('• Mail Icon', 0.8, 0.8, 0.8)
+    GameTooltip:AddLine('• Tracking Icon', 0.8, 0.8, 0.8)
+    GameTooltip:AddLine('• Resource Bar', 0.8, 0.8, 0.8)
+    GameTooltip:AddLine('• Resource Indicator', 0.8, 0.8, 0.8)
+    GameTooltip:AddLine('• Soulshard Indicator', 0.8, 0.8, 0.8)
+    GameTooltip:AddLine('• Statistics Panel', 0.8, 0.8, 0.8)
+    GameTooltip:AddLine('• ULTRA Menu', 0.8, 0.8, 0.8)
+    GameTooltip:AddLine(' ')
+    GameTooltip:AddLine('Note: This does not reset scale settings.', 1, 0.5, 0.5)
+    GameTooltip:Show()
+  end)
+  resetUIButton:SetScript('OnLeave', function()
+    GameTooltip:Hide()
+  end)
+
   local function toggleUICollapsing(forceCollapse)
     if forceCollapse ~= nil then
       colorCollapsed = forceCollapse
@@ -2156,18 +2175,27 @@ function InitializeSettingsOptionsTab()
       for _, item in ipairs(uiSettingsRows) do
         item:Hide()
       end
+      resetUIButton:Hide()
       colorHeaderIcon:SetTexture('Interface\\Buttons\\UI-PlusButton-Up')
       colorSectionFrame:SetHeight(LAYOUT.HEADER_HEIGHT)
     else
       -- Reflow will show correct children
       local h = reflowUISettings(_G.__UHC_CurrentSearchQuery)
+      resetUIButton:Show()
       colorHeaderIcon:SetTexture('Interface\\Buttons\\UI-MinusButton-Up')
-      colorSectionFrame:SetHeight(h)
+      colorSectionFrame:SetHeight(h + 50) -- Add space for button
     end
   end
 
   _G.__UHC_ToggleUISettingsCollapse = function(val)
     toggleUICollapsing(val)
+  end
+
+  -- Set initial button visibility based on collapsed state
+  if colorCollapsed then
+    resetUIButton:Hide()
+  else
+    resetUIButton:Show()
   end
 
   toggleUICollapsing(colorCollapsed)

--- a/Settings/SettingsOptionsTab.lua
+++ b/Settings/SettingsOptionsTab.lua
@@ -1277,41 +1277,89 @@ function InitializeSettingsOptionsTab()
   saveButton:SetPoint('BOTTOM', tabContents[2], 'BOTTOM', 0, -40)
   saveButton:SetText('Save and Reload')
   saveButton:SetScript('OnClick', function()
-    for key, value in pairs(tempSettings) do
-      GLOBAL_SETTINGS[key] = value
-    end
+    if ShowConfirmationDialog then
+      ShowConfirmationDialog(
+        'Save and Reload',
+        'Are you sure you want to save your settings and reload the UI?',
+        function()
+          for key, value in pairs(tempSettings) do
+            GLOBAL_SETTINGS[key] = value
+          end
 
-    -- Apply the new completely remove settings immediately
-    SetPlayerFrameDisplay()
+          -- Apply the new completely remove settings immediately
+          SetPlayerFrameDisplay()
 
-    -- Set target frame accordingly
-    if GLOBAL_SETTINGS.hideTargetFrame or GLOBAL_SETTINGS.completelyRemoveTargetFrame then
-      SetTargetFrameDisplay({})
-    end
+          -- Set target frame accordingly
+          if GLOBAL_SETTINGS.hideTargetFrame or GLOBAL_SETTINGS.completelyRemoveTargetFrame then
+            SetTargetFrameDisplay({})
+          end
 
-    -- Handle XP Bar settings
-    if GLOBAL_SETTINGS.showExpBar then
-      InitializeExpBar()
+          -- Handle XP Bar settings
+          if GLOBAL_SETTINGS.showExpBar then
+            InitializeExpBar()
+          else
+            HideExpBar()
+          end
+
+          if GLOBAL_SETTINGS.hideDefaultExpBar then
+            HideDefaultExpBar()
+          else
+            ShowDefaultExpBar()
+          end
+
+          -- Update XP bar color and height if it exists
+          if _G.UpdateExpBarColor then
+            UpdateExpBarColor()
+          end
+          if _G.UpdateExpBarHeight then
+            UpdateExpBarHeight()
+          end
+
+          SaveCharacterSettings(GLOBAL_SETTINGS)
+          ReloadUI()
+        end,
+        nil,
+        'Save and Reload',
+        'Cancel'
+      )
     else
-      HideExpBar()
-    end
+      -- Fallback if confirmation dialog isn't loaded
+      for key, value in pairs(tempSettings) do
+        GLOBAL_SETTINGS[key] = value
+      end
 
-    if GLOBAL_SETTINGS.hideDefaultExpBar then
-      HideDefaultExpBar()
-    else
-      ShowDefaultExpBar()
-    end
+      -- Apply the new completely remove settings immediately
+      SetPlayerFrameDisplay()
 
-    -- Update XP bar color and height if it exists
-    if _G.UpdateExpBarColor then
-      UpdateExpBarColor()
-    end
-    if _G.UpdateExpBarHeight then
-      UpdateExpBarHeight()
-    end
+      -- Set target frame accordingly
+      if GLOBAL_SETTINGS.hideTargetFrame or GLOBAL_SETTINGS.completelyRemoveTargetFrame then
+        SetTargetFrameDisplay({})
+      end
 
-    SaveCharacterSettings(GLOBAL_SETTINGS)
-    ReloadUI()
+      -- Handle XP Bar settings
+      if GLOBAL_SETTINGS.showExpBar then
+        InitializeExpBar()
+      else
+        HideExpBar()
+      end
+
+      if GLOBAL_SETTINGS.hideDefaultExpBar then
+        HideDefaultExpBar()
+      else
+        ShowDefaultExpBar()
+      end
+
+      -- Update XP bar color and height if it exists
+      if _G.UpdateExpBarColor then
+        UpdateExpBarColor()
+      end
+      if _G.UpdateExpBarHeight then
+        UpdateExpBarHeight()
+      end
+
+      SaveCharacterSettings(GLOBAL_SETTINGS)
+      ReloadUI()
+    end
   end)
 
   _G.updateCheckboxes = updateCheckboxes
@@ -2141,8 +2189,24 @@ function InitializeSettingsOptionsTab()
   resetUIButton:SetText('Reset Positions')
   resetUIButton:SetPoint('BOTTOM', colorSectionFrame, 'BOTTOM', 0, 10)
   resetUIButton:SetScript('OnClick', function()
-    if SlashCmdList['RESETUI'] then
-      SlashCmdList['RESETUI']()
+    if ShowConfirmationDialog then
+      ShowConfirmationDialog(
+        'Reset UI Positions',
+        'Are you sure you want to reset all UI element positions to their defaults?',
+        function()
+          if SlashCmdList['RESETUI'] then
+            SlashCmdList['RESETUI']()
+          end
+        end,
+        nil,
+        'Reset',
+        'Cancel'
+      )
+    else
+      -- Fallback if confirmation dialog isn't loaded
+      if SlashCmdList['RESETUI'] then
+        SlashCmdList['RESETUI']()
+      end
     end
   end)
   resetUIButton:SetScript('OnEnter', function(self)

--- a/Settings/SettingsOptionsTab.lua
+++ b/Settings/SettingsOptionsTab.lua
@@ -1272,10 +1272,21 @@ function InitializeSettingsOptionsTab()
     _G.__UHC_SectionTitles = sectionTitles
   end
 
+  -- Create buttons centered at the bottom
+  local resetUIButton = CreateFrame('Button', nil, tabContents[2], 'UIPanelButtonTemplate')
+  resetUIButton:SetSize(140, 30)
+  resetUIButton:SetText('Reset Positions')
+  resetUIButton:SetPoint('BOTTOM', tabContents[2], 'BOTTOM', -77.5, -40)
+
   local saveButton = CreateFrame('Button', nil, tabContents[2], 'UIPanelButtonTemplate')
-  saveButton:SetSize(120, 30)
-  saveButton:SetPoint('BOTTOM', tabContents[2], 'BOTTOM', 0, -40)
+  saveButton:SetSize(150, 30)
   saveButton:SetText('Save and Reload')
+  saveButton:SetPoint('LEFT', resetUIButton, 'RIGHT', 10, 0)
+  resetUIButton:SetScript('OnClick', function()
+    if SlashCmdList['RESETUI'] then
+      SlashCmdList['RESETUI']()
+    end
+  end)
   saveButton:SetScript('OnClick', function()
     for key, value in pairs(tempSettings) do
       GLOBAL_SETTINGS[key] = value

--- a/UltraHardcore.toc
+++ b/UltraHardcore.toc
@@ -75,6 +75,7 @@ Functions/Utils/TwitchInvite.lua
 Functions/Utils/KofiInvite.lua
 Functions/Utils/TbcQuestionnaire.lua
 Functions/Utils/AboutAuthor.lua
+Functions/Utils/ResetUI.lua
 
 Functions/DB/LoadDBData.lua
 Functions/DB/SaveDBData.lua

--- a/UltraHardcore.toc
+++ b/UltraHardcore.toc
@@ -75,6 +75,7 @@ Functions/Utils/TwitchInvite.lua
 Functions/Utils/KofiInvite.lua
 Functions/Utils/TbcQuestionnaire.lua
 Functions/Utils/AboutAuthor.lua
+Functions/Utils/ConfirmationDialog.lua
 Functions/Utils/ResetUI.lua
 
 Functions/DB/LoadDBData.lua


### PR DESCRIPTION
Add combined reset command and button to reset positions of draggable components.

### Summary

- What does this PR change and why?
  - Adds a combined reset command (`/resetui` or `/rui`) that resets all draggable UI elements (clock, mail, tracking, resource bar, resource indicator, soulshard indicator, and statistics panel) to their default positions in one action
  - Adds a "Reset Positions" button in the Settings tab next to "Save and Reload" for quick access
  - Standardizes all reset messages to use the `|cfff44336[ULTRA]|r` format for consistency
  - Adds missing reset functions for Resource Indicator and Statistics Panel
  - Moves reset logic to a dedicated utility file (`Functions/Utils/ResetUI.lua`) for better code organization

- Link related issues (e.g., Fixes #123).
  - N/A

### Screenshots / Video (optional)
<img width="1013" height="776" alt="image" src="https://github.com/user-attachments/assets/e77463a9-a4a0-43d1-b09b-c7ad30e45466" />


### Testing Steps (in-game)

How to enable/trigger the feature.

1. Test matrix:
   - Open Settings tab (`/uhc`)
   - Click "Reset Positions" button at bottom of Settings tab
   - OR use slash command `/resetui` or `/rui` in chat
   - Reload UI (`/reload`)

2. Expected result:
   - All draggable UI elements (clock, mail, tracking icon, resource bar, resource indicator, soulshard indicator, statistics panel) should reset to their default positions
   - Chat should show individual reset messages for each element using `[ULTRA]` format
   - Final message: `[ULTRA] All UI element positions reset to default.`