### PR TITLE
Fixed Vitals Overlay being late to the party

### DIFF
--- a/Functions/Overlays/VitalsOverlay.lua
+++ b/Functions/Overlays/VitalsOverlay.lua
@@ -360,4 +360,6 @@ function SetVitalsOverlayEnabled(shouldEnable)
   end
 
   updateOverlayVisibility()
+  updateOverlayText()
 end
+


### PR DESCRIPTION
Added the missing updateOverlayText() in SetVitalsOverlayEnabled(shouldEnable).

### Summary

- This should fix the problem of the Vitals Overlay initially showing the health64 and mana64 icons without any values before updating to the correct values, as it should now always update the overlay whenever the visibility is toggled.

### Screenshots / Video (optional)

- none

### Testing Steps (in-game)

How to enable/trigger the feature.

1. Test matrix:
   - Wildly toggle Show Vitals Overlay with reloads inbetween
2. Expected result:
   - On a warrior or rogue, the mana64 icon should never show.
   - On classes using mana, it should always show the health64 icon and the mana64 icon with the correct values and never without values.

