### PR TITLE
Add files via upload

### DIFF
--- a/Settings/SettingsOptionsTab.lua
+++ b/Settings/SettingsOptionsTab.lua
@@ -45,6 +45,7 @@ local settingsCheckboxOptions = { {
   name = 'Tunnel Vision Covers Everything',
   dbSettingsValueName = 'tunnelVisionMaxStrata',
   tooltip = 'Tunnel Vision covers all UI elements',
+  dependsOn = 'showTunnelVision',
 }, {
   name = 'Route Planner',
   dbSettingsValueName = 'routePlanner',
@@ -173,6 +174,7 @@ local settingsCheckboxOptions = { {
   name = 'Seasonal-themed Tunnel Vision',
   dbSettingsValueName = 'spookyTunnelVision',
   tooltip = 'Use the latest holiday themed tunnel vision overlay',
+  dependsOn = 'showTunnelVision',
 }, {
   name = 'Roach Hearthstone In Party Combat',
   dbSettingsValueName = 'roachHearthstoneInPartyCombat',
@@ -185,6 +187,7 @@ local settingsCheckboxOptions = { {
   name = 'Show XP Bar Tooltip',
   dbSettingsValueName = 'showXpBarToolTip',
   tooltip = 'Shows detailed XP information when hovering over the XP bar (percentage and exact numbers)',
+  dependsOn = 'showExpBar',
 }, {
   name = 'Hide Default WoW XP Bar',
   dbSettingsValueName = 'hideDefaultExpBar',


### PR DESCRIPTION
### Summary

Added dependancies in the settings tab.
 - Show XP Bar Tooltip depends on Show XP Bar
 - Hide Default WoW XP Bar intentionally does NOT depend on Show XP Bar!
 - Seasonal-themed Tunnel Vision and Tunnel Vision Covers Everything depend on Show Tunnel Vision
 

### Screenshots / Video (optional)

<img width="313" height="179" alt="image" src="https://github.com/user-attachments/assets/8c1a7a43-af0d-46b6-ad62-8a547ed72503" />

### Testing Steps (in-game)

How to enable/trigger the feature.

1. Test matrix:
   - Reload UI (/reload)
2. Expected result:
   - The above stated dependancies should be implemented

