### PR TITLE
Resource map rotation

### DIFF
--- a/Constants/PresetSections.lua
+++ b/Constants/PresetSections.lua
@@ -50,7 +50,7 @@ local PRESET_SECTIONS = { {
   },
 }, {
   title = 'Maps:',
-  settings = { 'alwaysShowResourceMap', 'showPlayerArrowOnResourceMap' },
+  settings = { 'alwaysShowResourceMap', 'showPlayerArrowOnResourceMap', 'rotateMinimapOnResourceMap' },
 }, {
   title = 'Misc:',
   settings = {

--- a/Functions/DB/LoadDBData.lua
+++ b/Functions/DB/LoadDBData.lua
@@ -44,7 +44,7 @@ function LoadDBData()
     showFullHealthIndicator = false,
     hideCustomResourceBar = false,
     showHealingIndicator = false,
-    showWildAllyHealthIndicator = false,
+    showWildAllyHealthIndicator = true,
     setFirstPersonCamera = false,
     completelyRemovePlayerFrame = false,
     completelyRemoveTargetFrame = false,

--- a/Functions/DB/LoadDBData.lua
+++ b/Functions/DB/LoadDBData.lua
@@ -44,7 +44,7 @@ function LoadDBData()
     showFullHealthIndicator = false,
     hideCustomResourceBar = false,
     showHealingIndicator = false,
-    showWildAllyHealthIndicator = true,
+    showWildAllyHealthIndicator = false,
     setFirstPersonCamera = false,
     completelyRemovePlayerFrame = false,
     completelyRemoveTargetFrame = false,
@@ -141,4 +141,19 @@ function LoadDBData()
 
   -- Load current character's settings
   GLOBAL_SETTINGS = UltraHardcoreDB.characterSettings[characterGUID]
+
+  -- Always mirror the current WoW RotateMinimap CVar into our
+  -- rotateMinimapOnResourceMap flag on load so ULTRA starts in
+  -- the same state as the base game every session. The ULTRA
+  -- settings UI can change this by writing back to the CVar via
+  -- Save and Reload; after that, this will see the updated value.
+  do
+    local cvarValue = GetCVar('RotateMinimap')
+    if cvarValue ~= nil then
+      GLOBAL_SETTINGS.rotateMinimapOnResourceMap =
+        (cvarValue == '1' or cvarValue == 'true' or cvarValue == true)
+    else
+      GLOBAL_SETTINGS.rotateMinimapOnResourceMap = false
+    end
+  end
 end

--- a/Functions/SetMinimapDisplay.lua
+++ b/Functions/SetMinimapDisplay.lua
@@ -1,7 +1,5 @@
 local minimapHideTimer = nil
 local minimapCleanupTicker = nil
-local initialRotateMinimap = GetCVar("RotateMinimap") or false
-
 
 -- Track temporary reveal state so we can restore cleanly on any event
 local minimapRevealState = {
@@ -14,6 +12,7 @@ local minimapRevealState = {
   originalScale = nil,
   originalAlpha = nil,
   initialZoom = nil,
+  originalRotateMinimap = nil,
   toggledFrames = nil,
   toggledRegions = nil,
 }
@@ -55,7 +54,10 @@ local function ResetMinimapRevealState()
   if minimapRevealState.initialZoom ~= nil then
     Minimap:SetZoom(minimapRevealState.initialZoom)
   end
-  SetCVar("RotateMinimap", initialRotateMinimap)
+  -- Only restore RotateMinimap if we explicitly overrode it for a temporary reveal
+  if minimapRevealState.originalRotateMinimap ~= nil then
+    SetCVar("RotateMinimap", minimapRevealState.originalRotateMinimap)
+  end
 
   Minimap:ClearAllPoints()
   if minimapRevealState.originalParent then
@@ -345,8 +347,28 @@ function RevealMinimapForTracking(isAlwaysOn)
   -- Reset any existing reveal state to ensure we capture the true 'base' state
   ResetMinimapRevealState()
 
-  -- Temporarily make the minimap rotate with the user
-  SetCVar("RotateMinimap", true)
+  -- Rotation behaviour:
+  --  - If Always On resource map is NOT enabled (spell-based temporary reveal),
+  --    we snapshot the current RotateMinimap CVar and force rotation for the
+  --    duration of the overlay, then restore the snapshot afterwards.
+  --  - If Always On resource map IS enabled, we respect the user's ULTRA
+  --    setting (rotateMinimapOnResourceMap) and do NOT snapshot/restore,
+  --    so their underlying WoW minimap rotation preference is not overridden
+  --    when Always Show Resource Map is disabled.
+  if not isAlwaysOn then
+    minimapRevealState.originalRotateMinimap = GetCVar("RotateMinimap")
+    SetCVar("RotateMinimap", true)
+  else
+    local rotate
+    if GLOBAL_SETTINGS and GLOBAL_SETTINGS.rotateMinimapOnResourceMap ~= nil then
+      rotate = GLOBAL_SETTINGS.rotateMinimapOnResourceMap
+    else
+      local cvarValue = GetCVar("RotateMinimap")
+      rotate = (cvarValue == "1" or cvarValue == "true" or cvarValue == true)
+    end
+    SetCVar("RotateMinimap", rotate)
+    minimapRevealState.originalRotateMinimap = nil
+  end
 
   -- Allow clicks through minimap while this is up
   Minimap:EnableMouse(false)

--- a/Settings/SettingsOptionsTab.lua
+++ b/Settings/SettingsOptionsTab.lua
@@ -72,9 +72,10 @@ local settingsCheckboxOptions = { {
   dbSettingsValueName = 'showHealingIndicator',
   tooltip = 'Gold glow on the edges of the screen when you are healed',
 }, {
-  name = 'Wild Ally Health Indicator',
+  name = 'Friendly Health Indicators - Open World',
   dbSettingsValueName = 'showWildAllyHealthIndicator',
   tooltip = 'Replace friendly nameplates with a minimal health indicator for non-group allies',
+  dependsOn = 'disableNameplateHealth',
 }, {
   name = 'Hide Player Cast Bar',
   dbSettingsValueName = 'hidePlayerCastBar',

--- a/Settings/SettingsOptionsTab.lua
+++ b/Settings/SettingsOptionsTab.lua
@@ -72,10 +72,9 @@ local settingsCheckboxOptions = { {
   dbSettingsValueName = 'showHealingIndicator',
   tooltip = 'Gold glow on the edges of the screen when you are healed',
 }, {
-  name = 'Friendly Health Indicators - Open World',
+  name = 'Wild Ally Health Indicator',
   dbSettingsValueName = 'showWildAllyHealthIndicator',
   tooltip = 'Replace friendly nameplates with a minimal health indicator for non-group allies',
-  dependsOn = 'disableNameplateHealth',
 }, {
   name = 'Hide Player Cast Bar',
   dbSettingsValueName = 'hidePlayerCastBar',
@@ -213,13 +212,17 @@ local settingsCheckboxOptions = { {
 }, {
   name = 'Always Show Resource Map',
   dbSettingsValueName = 'alwaysShowResourceMap',
-  tooltip = 'Keep the transparent resource map visible in the normal minimap location (shows resource blips only).',
+  tooltip = 'Keep the transparent resource map visible in the normal minimap location (shows resource blips only)',
   dependsOn = 'hideMinimap',
 }, {
   name = 'Show Player Arrow on Resource Map',
   dbSettingsValueName = 'showPlayerArrowOnResourceMap',
   tooltip = 'Display the player arrow on the resource tracking map',
   dependsOn = 'alwaysShowResourceMap',
+}, {
+  name = 'Rotate Minimap',
+  dbSettingsValueName = 'rotateMinimapOnResourceMap',
+  tooltip = 'Rotate the minimap instead of keeping it static',
 }, {
   name = 'Show Tracking Button When Minimap is Hidden',
   dbSettingsValueName = 'showTrackingWhenMapHidden',
@@ -236,6 +239,10 @@ local settingsSliderOptions = { {
   maxValue = MAXIMUM_XP_BAR_HEIGHT,
   defaultValue = 3,
 } }
+
+-- Temporary per-session settings used by the options UI; only written back
+-- into GLOBAL_SETTINGS when the player clicks Save and Reload.
+tempSettings = tempSettings or {}
 
 local presets = { {
   -- Preset 1: Lite
@@ -357,6 +364,20 @@ function InitializeSettingsOptionsTab()
       tempSettings.lockResourceBar = GLOBAL_SETTINGS.lockResourceBar
     else
       tempSettings.lockResourceBar = false
+    end
+  end
+
+  -- Initialize Rotate Minimap for Resource Map to mirror the player's current
+  -- WoW minimap rotation preference the first time, so we don't hard-force
+  -- this option on or off by default. Subsequent changes are only saved when
+  -- the player clicks Save and Reload.
+  if tempSettings.rotateMinimapOnResourceMap == nil then
+    if GLOBAL_SETTINGS and GLOBAL_SETTINGS.rotateMinimapOnResourceMap ~= nil then
+      tempSettings.rotateMinimapOnResourceMap = GLOBAL_SETTINGS.rotateMinimapOnResourceMap
+    else
+      local cvarValue = GetCVar('RotateMinimap')
+      tempSettings.rotateMinimapOnResourceMap =
+        (cvarValue == '1' or cvarValue == 'true' or cvarValue == true)
     end
   end
 
@@ -1379,6 +1400,23 @@ function InitializeSettingsOptionsTab()
             GLOBAL_SETTINGS[key] = value
           end
 
+          -- If the player has chosen a Rotate Minimap state via the ULTRA
+          -- checkbox, write it back to the Blizzard CVar now so that on
+          -- next load ULTRA and the base game are in sync.
+          if tempSettings.rotateMinimapOnResourceMap ~= nil then
+            SetCVar(
+              'RotateMinimap',
+              tempSettings.rotateMinimapOnResourceMap and '1' or '0'
+            )
+          end
+
+          -- The player explicitly saved ULTRA settings; treat ULTRA as the
+          -- source of truth for minimap rotation until they change the WoW
+          -- RotateMinimap option again (which will flip the source back).
+          if GLOBAL_SETTINGS.rotateMinimapOnResourceMap ~= nil then
+            GLOBAL_SETTINGS.rotateMinimapSource = 'ultra'
+          end
+
           -- Apply the new completely remove settings immediately
           SetPlayerFrameDisplay()
 
@@ -1419,6 +1457,13 @@ function InitializeSettingsOptionsTab()
       -- Fallback if confirmation dialog isn't loaded
       for key, value in pairs(tempSettings) do
         GLOBAL_SETTINGS[key] = value
+      end
+
+      if tempSettings.rotateMinimapOnResourceMap ~= nil then
+        SetCVar(
+          'RotateMinimap',
+          tempSettings.rotateMinimapOnResourceMap and '1' or '0'
+        )
       end
 
       -- Apply the new completely remove settings immediately

--- a/UltraHardcore.lua
+++ b/UltraHardcore.lua
@@ -212,3 +212,31 @@ UltraHardcore:SetScript('OnEvent', function(self, event, ...)
     end
   end
 end)
+
+-- Mirror Blizzard's RotateMinimap CVar into ULTRA's rotateMinimapOnResourceMap
+-- setting whenever the player changes it in the default WoW options. This keeps
+-- the ULTRA checkbox in sync with the game's own option, without writing back
+-- to the CVar when the ULTRA setting changes (ULTRA only affects behaviour
+-- when Always Show Resource Map is active).
+local rotateMinimapWatcher = CreateFrame('Frame')
+rotateMinimapWatcher:RegisterEvent('CVAR_UPDATE')
+rotateMinimapWatcher:SetScript('OnEvent', function(_, name, value)
+  -- CVAR_UPDATE fires with the CVar name exactly as used in GetCVar/SetCVar.
+  if name ~= 'RotateMinimap' then return end
+
+  local isEnabled = (value == '1' or value == 'true' or value == true)
+
+  -- Update saved per-character setting so future sessions mirror Blizzard.
+  if GLOBAL_SETTINGS then
+    GLOBAL_SETTINGS.rotateMinimapOnResourceMap = isEnabled
+  end
+
+  -- If the Settings UI is currently open, update its temp copy and refresh
+  -- checkboxes so the ULTRA interface reflects the change "live".
+  if _G.tempSettings then
+    _G.tempSettings.rotateMinimapOnResourceMap = isEnabled
+  end
+  if _G.updateCheckboxes then
+    _G.updateCheckboxes()
+  end
+end)


### PR DESCRIPTION
### Summary

- No longer messes with users Rotate Minimap setting
- Changed the overlay to save the RotateMinimap cvar, then change the cvar, execute the overlay and switch back to the original cvar
- Added option "Rotate Minimap" into the Maps section that essentially toggles the cvar for the user on save & reload
- https://discord.com/channels/1343653057317048360/1451007223244525620

### Testing Steps (in-game)

How to enable/trigger the feature.

1. Test matrix:
   - Reload UI (/reload)
2. Expected result:
   - Regardless of RotateMinimap setting, the "big" resource overlay should work normally and revert the RotateMinimap setting back to what it was before executing it, if neccessary
   - If you set toggle the Ultra setting to rotate the minimap and then Save and Reload, the cvar gets changed
   - If you toggle the cvar through the WoW options and then /reload, the Ultra setting is toggled after the reload to match again
   - If you toggle the setting in Ultra and close out or manually /reload, no changes happen
   - If you toggle the cvar through the WoW options and don't /reload or log out, the Ultra setting is not changed until a reload happened. If you go into the Ultra settings in this case and click Save and Reload, the Ultra setting is priorized and overwrites the changed cvar setting. **This is a bug and can only be prevented my real-time updates in the Ultra settings**