### PR TITLE
Fix Missing PvP Icon on Target Frame

### DIFF
--- a/Functions/SetTargetFrameDisplay.lua
+++ b/Functions/SetTargetFrameDisplay.lua
@@ -58,6 +58,14 @@ local function ApplyPortrait()
   end
 end
 
+-- Show PVP icon
+local function ApplyPVPIcon()
+  local pvpIcon = _G.TargetFrameTextureFramePVPIcon
+  if pvpIcon then
+    pvpIcon:SetAlpha(1)
+  end
+end
+
 -- Show/hide buffs/debuffs
 local function ApplyAuras()
   local showBuffs = targetFrameMask.buffs
@@ -233,6 +241,7 @@ local function ApplyMask()
 
   HideSubFrames('TargetFrame')
   HideTextureRegions(TargetFrameTextureFrame)
+  ApplyPVPIcon()
   ApplyPortrait()
   ApplyRaidIcon()
   ApplyAuras()


### PR DESCRIPTION
### Summary

**What does this PR change?**
This PR updates `Functions/SetTargetFrameDisplay.lua` to explicitly preserve the visibility of the PvP Icon on the Target Frame. Specifically, it introduces a helper function `ApplyPVPIcon()` that sets the alpha of `TargetFrameTextureFramePVPIcon` back to `1` after the masking logic hides the texture regions.

**Why?**
In Hardcore mode, it is vital to know if a target (NPC or Player) is PvP-flagged to avoid accidental flagging. The previous logic in `HideTextureRegions` was inadvertently hiding the PvP shield, leaving the player blind to this danger.

While this information is technically available in the tooltip on mouseover (as you can see on the images), relying on that is inefficient and risky in split-second situations. Restoring the visual indicator on the unit frame ensures immediate awareness.

### Screenshots / Video

**Before (Bug):**
Target (guard) is PvP flagged, but no shield is shown on the custom portrait.
<img width="2559" height="1439" alt="UHC-ON-NO-CHANGES" src="https://github.com/user-attachments/assets/c89def0f-85a2-4c25-9db9-8a1f1d4ba8c7" />

**After (Fix):**
The shield is clearly visible on the portrait, correctly indicating PvP status.
<img width="2559" height="1439" alt="UHC-ON-WITH-CHANGES" src="https://github.com/user-attachments/assets/2188d4b0-5cb5-4618-86be-63d56da31b2e" />

### Testing steps (in-game)

**How to verify:**
1.  Log in to a character and reload UI ('/reload').
2.  Find a PvP-flagged NPC (e.g., an opposing faction guard or a friendly guard) or a flagged player.
3.  Target the NPC/Player.

**Expected result:**
* **PvP targets:** The faction PvP shield (Horde/Alliance icon) should be visible on the Target Frame portrait.
* **Non-PvP targets:** Should remain clean (no icon).

Notes: This shield icon will also be shown on friendly pvp flagged NPC, since that's the default wow behavior.