### PR TITLE
Feat toggleable death details

### DIFF
--- a/Constants/PresetSections.lua
+++ b/Constants/PresetSections.lua
@@ -62,6 +62,7 @@ local PRESET_SECTIONS = { {
     'useCustomComboFrame',
     'hideComboFrame',
     'announceLevelUpToGuild',
+    'announceDeathDetailsToGuild',
     'autoJoinUHCChannel',
     'hideUIErrors',
     'showClockEvenWhenMapHidden',

--- a/Functions/DB/CharacterStats.lua
+++ b/Functions/DB/CharacterStats.lua
@@ -16,6 +16,7 @@ local CharacterStats = {
     xpGainedWithoutOptionShowOnScreenStatistics = 0,
     xpGainedWithoutOptionShowTunnelVision = 0,
     xpGainedWithoutOptionAnnounceLevelUpToGuild = 0,
+    xpGainedWithoutOptionAnnounceDeathDetailsToGuild = 0,
     xpGainedWithoutOptionTunnelVisionMaxStrata = 0,
     xpGainedWithoutOptionHideTargetFrame = 0,
     xpGainedWithoutOptionHideTargetTooltip = 0,

--- a/Functions/DB/LoadDBData.lua
+++ b/Functions/DB/LoadDBData.lua
@@ -62,6 +62,7 @@ function LoadDBData()
     minimapClockScale = 1.0,
     minimapMailScale = 1.0,
     announceLevelUpToGuild = true,
+    announceDeathDetailsToGuild = true,
     autoJoinUHCChannel = true,
     -- Hide JOIN/LEAVE spam for the 'uhc' channel in chat (client-side filter)
     suppressUHCChannelJoinLeaveNotices = true,

--- a/Functions/Statistics/TrackXPPerSetting.lua
+++ b/Functions/Statistics/TrackXPPerSetting.lua
@@ -13,6 +13,7 @@ local settingToXPVariable = {
   showOnScreenStatistics = 'xpGainedWithoutOptionShowOnScreenStatistics',
   showTunnelVision = 'xpGainedWithoutOptionShowTunnelVision',
   announceLevelUpToGuild = 'xpGainedWithoutOptionAnnounceLevelUpToGuild',
+  announceDeathDetailsToGuild = 'xpGainedWithoutOptionAnnounceDeathDetailsToGuild',
   -- Recommended Preset Settings
   tunnelVisionMaxStrata = 'xpGainedWithoutOptionTunnelVisionMaxStrata',
   hideTargetFrame = 'xpGainedWithoutOptionHideTargetFrame',

--- a/Functions/deathDetails.lua
+++ b/Functions/deathDetails.lua
@@ -205,7 +205,7 @@ function DeathDetails.HandlePlayerDeath(destGUID)
 
   -- Send to guild if player is in a guild
   local isInGuild = IsInGuild()
-  if isInGuild then
+  if isInGuild and GLOBAL_SETTINGS.announceDeathDetailsToGuild then
     SendChatMessage(message, 'GUILD')
   end
 

--- a/Settings/SettingsOptionsTab.lua
+++ b/Settings/SettingsOptionsTab.lua
@@ -139,6 +139,10 @@ local settingsCheckboxOptions = { {
   dbSettingsValueName = 'announceLevelUpToGuild',
   tooltip = 'Announces level ups to guild chat every 10th level',
 }, {
+  name = 'Announce Death Details to Guild',
+  dbSettingsValueName = 'announceDeathDetailsToGuild',
+  tooltip = 'Announces death details to guild chat when you die',
+}, {
   name = 'Auto Join ULTRA Channel',
   dbSettingsValueName = 'autoJoinUHCChannel',
   tooltip = 'Automatically join the ULTRA chat channel on login',


### PR DESCRIPTION
### Summary

- Added Misc option "Announce Death Details to Guild"

### Screenshots / Video (optional)

### Testing Steps (in-game)

How to enable/trigger the feature.

1. Test matrix:
   - Reload UI (/reload)
2. Expected result:
   - If the option is disabled, you don't announce the death message to the guild. Default setting for the option is "true"
